### PR TITLE
Allow sorting tables

### DIFF
--- a/lynxkite-app/web/src/index.css
+++ b/lynxkite-app/web/src/index.css
@@ -387,6 +387,14 @@ body {
     .image-in-table {
       max-height: 100px;
     }
+
+    .sort-indicator {
+      display: inline-block;
+      width: 0;
+      font-size: 10px;
+      color: #0006;
+      transform: translate(5px, -2px);
+    }
   }
 }
 

--- a/lynxkite-app/web/src/workspace/nodes/NodeWithVisualization.tsx
+++ b/lynxkite-app/web/src/workspace/nodes/NodeWithVisualization.tsx
@@ -20,7 +20,8 @@ function NodeWithVisualization(props: any) {
     });
     chartsInstanceRef.current.setOption(opts);
     const resizeObserver = new ResizeObserver(() => {
-      const e = chartsRef.current!;
+      const e = chartsRef.current;
+      if (!e) return;
       e.style.padding = "1px";
       chartsInstanceRef.current?.resize();
       e.style.padding = "0";

--- a/lynxkite-app/web/src/workspace/nodes/Table.tsx
+++ b/lynxkite-app/web/src/workspace/nodes/Table.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 function Cell({ value }: { value: any }) {
   if (typeof value === "string") {
     if (value.startsWith("https://") || value.startsWith("data:")) {
@@ -14,17 +16,48 @@ function Cell({ value }: { value: any }) {
 }
 
 export default function Table(props: any) {
+  const [sortColumn, setSortColumn] = useState<string | null>(null);
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
+  function onClick(column: string) {
+    if (sortColumn === column) {
+      setSortDirection(sortDirection === "asc" ? "desc" : "asc");
+    } else {
+      setSortColumn(column);
+      setSortDirection("asc");
+    }
+  }
+  let data = props.data;
+  const sortColumnIndex = props.columns.indexOf(sortColumn);
+  if (sortColumnIndex >= 0) {
+    data = [...props.data];
+    data.sort((a: any[], b: any[]) => {
+      const aValue = a[sortColumnIndex];
+      const bValue = b[sortColumnIndex];
+      if (aValue < bValue) {
+        return sortDirection === "asc" ? -1 : 1;
+      }
+      if (aValue > bValue) {
+        return sortDirection === "asc" ? 1 : -1;
+      }
+      return 0;
+    });
+  }
   return (
     <table className="table-viewer">
       <thead>
         <tr>
           {props.columns.map((column: string) => (
-            <th key={column}>{column}</th>
+            <th key={column} onClick={() => onClick(column)}>
+              {column}
+              {sortColumn === column && (
+                <span className="sort-indicator">{sortDirection === "asc" ? "▲" : "▼"}</span>
+              )}
+            </th>
           ))}
         </tr>
       </thead>
       <tbody>
-        {props.data.map((row: { [column: string]: any }, i: number) => (
+        {data.map((row: { [column: string]: any }, i: number) => (
           <tr key={`row-${i}`}>
             {props.columns.map((_column: string, j: number) => (
               <td key={`cell ${i}, ${j}`}>


### PR DESCRIPTION
Also for https://github.com/biggraph/lynxkite-2000-enterprise/issues/218.

I was planning to use a professional table component instead of rolling our own. But the ones I tried didn't play well with ReactFlow's nodes. So for now it seems we are stuck with our own basic table. Might as well add a few basic features!