### PR TITLE
Special characters in workspace name cause bugs

### DIFF
--- a/lynxkite-app/web/src/Code.tsx
+++ b/lynxkite-app/web/src/Code.tsx
@@ -50,9 +50,13 @@ export default function Code() {
     yDocRef.current = new Y.Doc();
     const text = yDocRef.current.getText("text");
     const proto = location.protocol === "https:" ? "wss:" : "ws:";
+    const encodedPath = path!
+      .split("/")
+      .map((segment) => encodeURIComponent(segment))
+      .join("/");
     wsProviderRef.current = new WebsocketProvider(
       `${proto}//${location.host}/ws/code/crdt`,
-      path!,
+      encodedPath!,
       yDocRef.current,
     );
     editorRef.current.getModel()!.setEOL(0); // https://github.com/yjs/y-monaco/issues/6
@@ -85,7 +89,13 @@ export default function Code() {
           <button className="btn btn-link">
             <Backspace />
           </button>
-          <Link to={`/dir/${parentDir}`} className="btn btn-link">
+          <Link
+            to={`/dir/${parentDir
+              .split("/")
+              .map((segment) => encodeURIComponent(segment))
+              .join("/")}`}
+            className="btn btn-link"
+          >
             <Close />
           </Link>
         </div>

--- a/lynxkite-app/web/src/Code.tsx
+++ b/lynxkite-app/web/src/Code.tsx
@@ -73,7 +73,7 @@ export default function Code() {
   return (
     <div className="workspace">
       <div className="top-bar bg-neutral">
-        <Link className="logo" to="">
+        <Link className="logo" to="/">
           <img alt="" src={favicon} />
         </Link>
         <div className="ws-name">{path}</div>

--- a/lynxkite-app/web/src/Directory.tsx
+++ b/lynxkite-app/web/src/Directory.tsx
@@ -29,7 +29,7 @@ function EntryCreator(props: {
   onCreate: (name: string) => void;
 }) {
   const [isCreating, setIsCreating] = useState(false);
-  const [error, setError] = useState("");
+  const [nameValidationError, setError] = useState("");
 
   function validateName(name: string): boolean {
     if (name.includes("/")) {
@@ -58,7 +58,7 @@ function EntryCreator(props: {
           }}
         >
           <input
-            className={`input input-ghost w-full ${error ? "input-error" : ""}`}
+            className={`input input-ghost w-full ${nameValidationError ? "input-error" : ""}`}
             autoFocus
             type="text"
             name="entryName"
@@ -66,7 +66,7 @@ function EntryCreator(props: {
             onChange={(e) => validateName(e.target.value)}
             placeholder={`${props.label} name`}
           />
-          {error && (
+          {nameValidationError && (
             <div
               className="error-message"
               role="alert"
@@ -75,7 +75,7 @@ function EntryCreator(props: {
               <span className="error-icon" aria-hidden="true">
                 ⚠️
               </span>
-              <span className="error-text">{error}</span>
+              <span className="error-text">{nameValidationError}</span>
             </div>
           )}
         </form>
@@ -99,10 +99,7 @@ export default function Directory() {
   const navigate = useNavigate();
 
   function link(item: DirectoryEntry) {
-    const encodedName = item.name
-      .split("/")
-      .map((segment) => encodeURIComponent(segment))
-      .join("/");
+    const encodedName = encodePathSegments(item.name);
     if (item.type === "directory") {
       return `/dir/${encodedName}`;
     }
@@ -119,24 +116,19 @@ export default function Directory() {
       ?.replace(/[.]lynxkite[.]json$/, "");
   }
 
+  function encodePathSegments(path: string): string {
+    const segments = path.split("/");
+    return segments.map((segment) => encodeURIComponent(segment)).join("/");
+  }
+
   function newWorkspaceIn(path: string, workspaceName: string) {
-    const pathSlash = path
-      ? `${path
-          .split("/")
-          .map((segment) => encodeURIComponent(segment))
-          .join("/")}/`
-      : "";
+    const pathSlash = path ? `${encodePathSegments(path)}/` : "";
     navigate(`/edit/${pathSlash}${encodeURIComponent(workspaceName)}.lynxkite.json`, {
       replace: true,
     });
   }
   function newCodeFile(path: string, name: string) {
-    const pathSlash = path
-      ? `${path
-          .split("/")
-          .map((segment) => encodeURIComponent(segment))
-          .join("/")}/`
-      : "";
+    const pathSlash = path ? `${encodePathSegments(path)}/` : "";
     navigate(`/code/${pathSlash}${encodeURIComponent(name)}`, { replace: true });
   }
   async function newFolderIn(path: string, folderName: string) {
@@ -147,12 +139,7 @@ export default function Directory() {
       body: JSON.stringify({ path: pathSlash + folderName }),
     });
     if (res.ok) {
-      const pathSlash = path
-        ? `${path
-            .split("/")
-            .map((segment) => encodeURIComponent(segment))
-            .join("/")}/`
-        : "";
+      const pathSlash = path ? `${encodePathSegments(path)}/` : "";
       navigate(`/dir/${pathSlash}${encodeURIComponent(folderName)}`);
     } else {
       alert("Failed to create folder.");

--- a/lynxkite-app/web/src/Directory.tsx
+++ b/lynxkite-app/web/src/Directory.tsx
@@ -67,13 +67,14 @@ export default function Directory() {
   const navigate = useNavigate();
 
   function link(item: DirectoryEntry) {
+    const encodedName = encodeURI(item.name);
     if (item.type === "directory") {
-      return `/dir/${item.name}`;
+      return `/dir/${encodedName}`;
     }
     if (item.type === "workspace") {
-      return `/edit/${item.name}`;
+      return `/edit/${encodedName}`;
     }
-    return `/code/${item.name}`;
+    return `/code/${encodedName}`;
   }
 
   function shortName(item: DirectoryEntry) {
@@ -85,11 +86,13 @@ export default function Directory() {
 
   function newWorkspaceIn(path: string, workspaceName: string) {
     const pathSlash = path ? `${path}/` : "";
-    navigate(`/edit/${pathSlash}${workspaceName}.lynxkite.json`, { replace: true });
+    navigate(`/edit/${encodeURI(pathSlash)}${encodeURIComponent(workspaceName)}.lynxkite.json`, {
+      replace: true,
+    });
   }
   function newCodeFile(path: string, name: string) {
     const pathSlash = path ? `${path}/` : "";
-    navigate(`/code/${pathSlash}${name}`, { replace: true });
+    navigate(`/code/${encodeURI(pathSlash)}${encodeURIComponent(name)}`, { replace: true });
   }
   async function newFolderIn(path: string, folderName: string) {
     const pathSlash = path ? `${path}/` : "";
@@ -99,7 +102,7 @@ export default function Directory() {
       body: JSON.stringify({ path: pathSlash + folderName }),
     });
     if (res.ok) {
-      navigate(`/dir/${pathSlash}${folderName}`);
+      navigate(`/dir/${encodeURI(pathSlash)}${encodeURIComponent(folderName)}`);
     } else {
       alert("Failed to create folder.");
     }

--- a/lynxkite-app/web/src/Directory.tsx
+++ b/lynxkite-app/web/src/Directory.tsx
@@ -72,7 +72,7 @@ function EntryCreator(props: {
               role="alert"
               style={{ position: "absolute", zIndex: 10 }}
             >
-              <span className="error-icon">⚠️</span>
+              <span className="error-icon" aria-hidden="true">⚠️</span>
               <span className="error-text">{error}</span>
             </div>
           )}

--- a/lynxkite-app/web/src/Directory.tsx
+++ b/lynxkite-app/web/src/Directory.tsx
@@ -29,18 +29,18 @@ function EntryCreator(props: {
   onCreate: (name: string) => void;
 }) {
   const [isCreating, setIsCreating] = useState(false);
-  const [nameValidationError, setError] = useState("");
+  const [nameValidationError, setNameValidationError] = useState("");
 
   function validateName(name: string): boolean {
     if (name.includes("/")) {
-      setError("Name cannot contain '/' characters");
+      setNameValidationError("Name cannot contain '/' characters");
       return false;
     }
     if (name.trim() === "") {
-      setError("Name cannot be empty");
+      setNameValidationError("Name cannot be empty");
       return false;
     }
-    setError("");
+    setNameValidationError("");
     return true;
   }
 

--- a/lynxkite-app/web/src/Directory.tsx
+++ b/lynxkite-app/web/src/Directory.tsx
@@ -72,7 +72,9 @@ function EntryCreator(props: {
               role="alert"
               style={{ position: "absolute", zIndex: 10 }}
             >
-              <span className="error-icon" aria-hidden="true">⚠️</span>
+              <span className="error-icon" aria-hidden="true">
+                ⚠️
+              </span>
               <span className="error-text">{error}</span>
             </div>
           )}

--- a/lynxkite-app/web/src/index.css
+++ b/lynxkite-app/web/src/index.css
@@ -704,3 +704,29 @@ body {
   left: -4px;
   top: -5px;
 }
+
+.error-message {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+  padding: 0.5rem;
+  background-color: #fee2e2;
+  border: 1px solid #fecaca;
+  border-radius: 0.375rem;
+  color: #dc2626;
+  font-size: 0.875rem;
+}
+
+.error-icon {
+  flex-shrink: 0;
+}
+
+.error-text {
+  line-height: 1.4;
+}
+
+.input-error {
+  border-color: #dc2626;
+  box-shadow: 0 0 0 1px #dc2626;
+}

--- a/lynxkite-app/web/src/workspace/Workspace.tsx
+++ b/lynxkite-app/web/src/workspace/Workspace.tsx
@@ -209,7 +209,7 @@ function LynxKiteFlow() {
     .map((segment) => encodeURIComponent(segment))
     .join("/");
   const catalog = useSWR(
-    `/api/catalog?workspace=${encodeURIComponent(encodedPathForAPI)}`,
+    `/api/catalog?workspace=${encodedPathForAPI}`,
     fetcher,
   );
   const [suppressSearchUntil, setSuppressSearchUntil] = useState(0);

--- a/lynxkite-app/web/src/workspace/Workspace.tsx
+++ b/lynxkite-app/web/src/workspace/Workspace.tsx
@@ -208,10 +208,7 @@ function LynxKiteFlow() {
     .split("/")
     .map((segment) => encodeURIComponent(segment))
     .join("/");
-  const catalog = useSWR(
-    `/api/catalog?workspace=${encodedPathForAPI}`,
-    fetcher,
-  );
+  const catalog = useSWR(`/api/catalog?workspace=${encodedPathForAPI}`, fetcher);
   const [suppressSearchUntil, setSuppressSearchUntil] = useState(0);
   const [nodeSearchSettings, setNodeSearchSettings] = useState(
     undefined as

--- a/lynxkite-app/web/src/workspace/Workspace.tsx
+++ b/lynxkite-app/web/src/workspace/Workspace.tsx
@@ -81,7 +81,15 @@ function LynxKiteFlow() {
     setState(state);
     const doc = getYjsDoc(state);
     const proto = location.protocol === "https:" ? "wss:" : "ws:";
-    const wsProvider = new WebsocketProvider(`${proto}//${location.host}/ws/crdt`, path!, doc);
+    const encodedPath = path!
+      .split("/")
+      .map((segment) => encodeURIComponent(segment))
+      .join("/");
+    const wsProvider = new WebsocketProvider(
+      `${proto}//${location.host}/ws/crdt`,
+      encodedPath,
+      doc,
+    );
     if (state.workspace && typeof state.workspace.paused === "undefined") {
       state.workspace.paused = false;
     }
@@ -196,7 +204,14 @@ function LynxKiteFlow() {
 
   const fetcher: Fetcher<Catalogs> = (resource: string, init?: RequestInit) =>
     fetch(resource, init).then((res) => res.json());
-  const catalog = useSWR(`/api/catalog?workspace=${path}`, fetcher);
+  const encodedPathForAPI = path!
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  const catalog = useSWR(
+    `/api/catalog?workspace=${encodeURIComponent(encodedPathForAPI)}`,
+    fetcher,
+  );
   const [suppressSearchUntil, setSuppressSearchUntil] = useState(0);
   const [nodeSearchSettings, setNodeSearchSettings] = useState(
     undefined as
@@ -565,7 +580,14 @@ function LynxKiteFlow() {
             </button>
           </Tooltip>
           <Tooltip doc="Close workspace">
-            <Link className="btn btn-link" to={`/dir/${parentDir}`} aria-label="close">
+            <Link
+              className="btn btn-link"
+              to={`/dir/${parentDir
+                .split("/")
+                .map((segment) => encodeURIComponent(segment))
+                .join("/")}`}
+              aria-label="close"
+            >
               <Close />
             </Link>
           </Tooltip>

--- a/lynxkite-app/web/src/workspace/Workspace.tsx
+++ b/lynxkite-app/web/src/workspace/Workspace.tsx
@@ -108,6 +108,7 @@ function LynxKiteFlow() {
           // Make sure the internal copies are updated.
           updateNodeInternals(node.id);
         }
+        setPausedUIState(state.workspace.paused || false);
       }
     };
     doc.on("update", onChange);
@@ -409,7 +410,7 @@ function LynxKiteFlow() {
     }
   }
   async function executeWorkspace() {
-    const response = await axios.post(`/api/execute_workspace?name=${path}`);
+    const response = await axios.post(`/api/execute_workspace?name=${encodeURIComponent(path)}`);
     if (response.status !== 200) {
       setMessage("Workspace execution failed.");
     }


### PR DESCRIPTION
Fixes #34.
The culprit was that we did not encode the URIs and I think I have fixed that in all places. I self tested these with these (` §'"+!%=(),.-~ˇ^˘°˛``˙´ `) special characters and all actions (create folder, create file, create workspace, and all of these nested) and they seemed to work fine, and I have not seen any crashes since.