### PR TITLE
Composable pytorch layers

### DIFF
--- a/lynxkite-graph-analytics/src/lynxkite_graph_analytics/pytorch/pytorch_ops.py
+++ b/lynxkite-graph-analytics/src/lynxkite_graph_analytics/pytorch/pytorch_ops.py
@@ -158,6 +158,17 @@ def concatenate(a, b):
     return lambda a, b: torch.concatenate(*torch.broadcast_tensors(a, b))
 
 
+@op("Test nested layers")
+def test_nested_layers(x: torch.Tensor, a: torch.nn.Module, b: torch.nn.Module):
+    """
+    This is a test function to demonstrate nested layers.
+    It creates a simple MLP with two layers.
+    """
+    print("A ", a)
+    print("B ", b)
+    return torch.nn.Sequential(a, b)
+
+
 reg(
     "Pick element by index",
     inputs=["x", "index"],

--- a/lynxkite-graph-analytics/src/lynxkite_graph_analytics/pytorch/pytorch_ops.py
+++ b/lynxkite-graph-analytics/src/lynxkite_graph_analytics/pytorch/pytorch_ops.py
@@ -115,7 +115,7 @@ def dropout(x, *, p=0.0):
 
 
 @op("Linear", weights=True)
-def linear(x, *, output_dim=1024):
+def linear(x: torch.Tensor, *, output_dim=1024):
     import torch_geometric.nn as pyg_nn
 
     return pyg_nn.Linear(-1, output_dim)
@@ -156,17 +156,6 @@ def embedding(x, *, num_embeddings: int, embedding_dim: int):
 @op("Concatenate")
 def concatenate(a, b):
     return lambda a, b: torch.concatenate(*torch.broadcast_tensors(a, b))
-
-
-@op("Test nested layers")
-def test_nested_layers(x: torch.Tensor, a: torch.nn.Module, b: torch.nn.Module):
-    """
-    This is a test function to demonstrate nested layers.
-    It creates a simple MLP with two layers.
-    """
-    print("A ", a)
-    print("B ", b)
-    return torch.nn.Sequential(a, b)
 
 
 reg(


### PR DESCRIPTION
**Add support to create hierarchical models by specifying Pytorch modules as inputs of other modules.**
I have done it by identifying a new type of node, the submodule. A submodule is a node in the workspace whose output is connected to an input of another node, and that input is of type `torch.nn.Module` or `list[torch.nn.Module]`.
A submodule doesn't add a Layer to the final model, instead it is stored on a new `submodoles` dict, to be later retrieved by the operation that uses it.


**Add support for `list` inputs in Pytorch environment.**
Copied over from https://github.com/biggraph/lynxkite-2000-enterprise/pull/220 , I think it makes sense to include this change here.