### PR TITLE
Fix union typed parameters with docstrings

### DIFF
--- a/lynxkite-core/src/lynxkite/core/ops.py
+++ b/lynxkite-core/src/lynxkite/core/ops.py
@@ -532,7 +532,7 @@ def _get_griffe_function(func):
         if param.annotation is inspect.Parameter.empty:
             annotation = None
         else:
-            annotation = param.annotation.__name__
+            annotation = getattr(param.annotation, "__name__", str(param.annotation))
         parameters.append(
             griffe.Parameter(
                 name,

--- a/lynxkite-core/tests/test_simple.py
+++ b/lynxkite-core/tests/test_simple.py
@@ -9,6 +9,7 @@ async def test_optional_inputs():
 
     @ops.op("test", "maybe add")
     def maybe_add(a: int, b: int | None = None):
+        """b is optional"""
         return a + (b or 0)
 
     assert maybe_add.__op__.inputs == [


### PR DESCRIPTION
Fixes the issue described in https://github.com/lynxkite/lynxkite-2000/pull/42#discussion_r2200730519. We even had a test for the `| None` thing, but apparently the test was missing a docstring...

I'm not happy with what's happening with UnionTypes. I don't know how it could be avoided, but it's annoying. `type(int)` or `type(Exception)` or the type of any type is `type`. But `type(int | None)` is `types.UnionType`, which is a subclass of `type`. And `UnionType` is different from `type` in many ways, like in this case I couldn't find a uniform way of turning them into a string. (`str(int | None)` is `int | None`, but `str(int)` is `<class 'int'>`.)