### PR TITLE
Smooth panning across nodes

### DIFF
--- a/lynxkite-app/web/src/index.css
+++ b/lynxkite-app/web/src/index.css
@@ -81,7 +81,7 @@ body {
     display: flex;
     flex-direction: column;
 
-    > :not(.title) {
+    > :not(.title, .react-flow__handle) {
       user-select: text;
       cursor: default;
     }


### PR DESCRIPTION
Fixes #21. This fixes both the zooming and the panning issue. The zoom is the easy part. For panning, now if there's nothing scrollable on the node, or we've already hit the end of scrolling, then it will pan. Seems to work well!

https://github.com/user-attachments/assets/1f6b283e-3fe4-4f32-b68a-ee098f074db5

