### PR TITLE
Use uv_build instead of setuptools

### DIFF
--- a/lynxkite-core/pyproject.toml
+++ b/lynxkite-core/pyproject.toml
@@ -17,9 +17,9 @@ DEP001 = ["matplotlib", "griffe", "pycrdt"]
 DEP003 = ["matplotlib", "griffe", "pycrdt"]
 
 [build-system]
-requires = ["setuptools", "wheel", "setuptools-scm"]
-build-backend = "setuptools.build_meta"
+requires = ["uv_build>=0.8.0,<0.9.0"]
+build-backend = "uv_build"
 
-[tool.setuptools.packages.find]
-namespaces = true
-where = ["src"]
+[tool.uv.build-backend]
+module-name = "lynxkite.core"
+namespace = true

--- a/lynxkite-graph-analytics/pyproject.toml
+++ b/lynxkite-graph-analytics/pyproject.toml
@@ -59,9 +59,5 @@ cuml-cu12 = "cuml"
 cudf-cu12 = "cudf"
 
 [build-system]
-requires = ["setuptools", "wheel", "setuptools-scm"]
-build-backend = "setuptools.build_meta"
-
-[tool.setuptools.packages.find]
-namespaces = true
-where = ["src"]
+requires = ["uv_build>=0.8.0,<0.9.0"]
+build-backend = "uv_build"

--- a/lynxkite-pillow-example/pyproject.toml
+++ b/lynxkite-pillow-example/pyproject.toml
@@ -2,7 +2,6 @@
 name = "lynxkite-pillow-example"
 version = "0.1.0"
 description = "An example LynxKite plugin that wraps some Pillow image processing features in LynxKite operations"
-readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "fsspec>=2025.2.0",
@@ -22,9 +21,5 @@ lynxkite-core = "lynxkite"
 pillow = "PIL"
 
 [build-system]
-requires = ["setuptools", "wheel", "setuptools-scm"]
-build-backend = "setuptools.build_meta"
-
-[tool.setuptools.packages.find]
-namespaces = true
-where = ["src"]
+requires = ["uv_build>=0.8.0,<0.9.0"]
+build-backend = "uv_build"


### PR DESCRIPTION
For once I'm not doing this out of a desire to be hip. I'm trying to run `ty` on our "secret" extensions, and I think it doesn't work because of the setuptools build backend on `lynxkite-core`. (https://github.com/biggraph/lynxkite-2000-enterprise/pull/225)