### PR TITLE
Pan with left click drag, select with Shift drag

### DIFF
--- a/lynxkite-app/web/src/workspace/Workspace.tsx
+++ b/lynxkite-app/web/src/workspace/Workspace.tsx
@@ -709,8 +709,8 @@ function LynxKiteFlow() {
             minZoom={0.2}
             zoomOnScroll={true}
             panOnScroll={false}
-            panOnDrag={[1]}
-            selectionOnDrag={true}
+            panOnDrag={[0]}
+            selectionOnDrag={false}
             preventScrolling={true}
             defaultEdgeOptions={{
               markerEnd: {


### PR DESCRIPTION
We had a discussion about it with Daniel and decided to go against https://github.com/biggraph/lynxkite-2000-enterprise/issues/249. Panning with the middle mouse button is hard to discover and near impossible on a touchpad. Panning is more important than selection, so let's make it the default action.