### PR TITLE
Match <input> borders on <textarea> and <select> elements

### DIFF
--- a/lynxkite-app/web/src/index.css
+++ b/lynxkite-app/web/src/index.css
@@ -296,7 +296,9 @@ svg {
       padding: 4px 8px 4px 8px;
       display: block;
 
-      input {
+      input,
+      textarea,
+      select {
         border-color: oklch(90% 0 0);
       }
     }
@@ -845,4 +847,9 @@ svg {
   p:not(:last-child) {
     margin-bottom: 10px;
   }
+}
+
+select,
+textarea {
+  border: var(--border) solid #0000;
 }


### PR DESCRIPTION
I thought this was a Mac issue, but now I think it's fallout from #89. I guess something changed in DaisyUI, causing textareas and selects to have a strong black border. This PR puts them back as they were before.