### PR TITLE
Make "name" a required field for relation definitions

### DIFF
--- a/lynxkite-graph-analytics/src/lynxkite_graph_analytics/core.py
+++ b/lynxkite-graph-analytics/src/lynxkite_graph_analytics/core.py
@@ -82,7 +82,7 @@ class RelationDefinition:
     target_table: str
     source_key: str
     target_key: str
-    name: str | None = None
+    name: str
 
 
 @dataclasses.dataclass
@@ -118,6 +118,7 @@ class Bundle:
             dfs={"edges": edges, "nodes": nodes},
             relations=[
                 RelationDefinition(
+                    name="edges",
                     df="edges",
                     source_column="source",
                     target_column="target",


### PR DESCRIPTION
We don't have a lot of places creating RelationDefinitions, so it's not too late to change this. Without a name the UI was just displaying "null" which looked like a bug. No reason not to have a name always.