### PR TITLE
Button to change box type

### DIFF
--- a/lynxkite-app/web/src/index.css
+++ b/lynxkite-app/web/src/index.css
@@ -62,6 +62,10 @@ svg {
         font-size: 1.5em;
         padding: 0 10px;
       }
+
+      .btn:disabled {
+        opacity: 0.3;
+      }
     }
   }
 

--- a/lynxkite-app/web/src/workspace/Workspace.tsx
+++ b/lynxkite-app/web/src/workspace/Workspace.tsx
@@ -27,6 +27,8 @@ import Play from "~icons/tabler/player-play.jsx";
 // @ts-expect-error
 import Restart from "~icons/tabler/rotate-clockwise.jsx";
 // @ts-expect-error
+import Transfer from "~icons/tabler/transfer.jsx";
+// @ts-expect-error
 import Close from "~icons/tabler/x.jsx";
 import type { Op as OpsOp, WorkspaceNode } from "../apiTypes.ts";
 import favicon from "../assets/favicon.ico";
@@ -333,6 +335,10 @@ function LynxKiteFlow() {
     const selectedEdges = edges.filter((e) => e.selected);
     reactFlow.deleteElements({ nodes: selectedNodes, edges: selectedEdges });
   }
+  function changeBox() {
+    const [selectedNode] = nodes.filter((n) => n.selected);
+    reactFlow.updateNodeData(selectedNode.id, { op_id: "" });
+  }
   function groupSelection() {
     const selectedNodes = nodes.filter((n) => n.selected && !n.parentId);
     const groupNode = {
@@ -407,7 +413,7 @@ function LynxKiteFlow() {
       }
     });
   }
-  const areMultipleNodesSelected = nodes.filter((n) => n.selected).length > 1;
+  const selected = nodes.filter((n) => n.selected);
   const isAnyGroupSelected = nodes.some((n) => n.selected && n.type === "node_group");
   return (
     <div className="workspace">
@@ -423,23 +429,36 @@ function LynxKiteFlow() {
           onChange={crdt.setEnv}
         />
         <div className="tools text-secondary">
-          {areMultipleNodesSelected && (
-            <Tooltip doc="Group selected nodes">
-              <button className="btn btn-link" onClick={groupSelection}>
-                <GroupIcon />
-              </button>
-            </Tooltip>
-          )}
-          {isAnyGroupSelected && (
-            <Tooltip doc="Ungroup selected nodes">
-              <button className="btn btn-link" onClick={ungroupSelection}>
-                <UngroupIcon />
-              </button>
-            </Tooltip>
-          )}
+          <Tooltip doc="Group selected nodes">
+            <button
+              className="btn btn-link"
+              disabled={selected.length < 2}
+              onClick={groupSelection}
+            >
+              <GroupIcon />
+            </button>
+          </Tooltip>
+          <Tooltip doc="Ungroup selected nodes">
+            <button
+              className="btn btn-link"
+              disabled={!isAnyGroupSelected}
+              onClick={ungroupSelection}
+            >
+              <UngroupIcon />
+            </button>
+          </Tooltip>
           <Tooltip doc="Delete selected nodes and edges">
-            <button className="btn btn-link" onClick={deleteSelection}>
+            <button
+              className="btn btn-link"
+              disabled={selected.length === 0}
+              onClick={deleteSelection}
+            >
               <Backspace />
+            </button>
+          </Tooltip>
+          <Tooltip doc="Change selected box to a different box">
+            <button className="btn btn-link" disabled={selected.length !== 1} onClick={changeBox}>
+              <Transfer />
             </button>
           </Tooltip>
           <Tooltip

--- a/lynxkite-app/web/src/workspace/crdt.ts
+++ b/lynxkite-app/web/src/workspace/crdt.ts
@@ -185,6 +185,9 @@ class CRDTConnection {
           if (wdata.get("op_id") !== data.op_id) {
             wdata.set("op_id", data.op_id);
           }
+          if (wdata.get("error") !== data.error) {
+            wdata.set("error", data.error);
+          }
           if (wdata.get("collapsed") !== data.collapsed) {
             wdata.set("collapsed", data.collapsed);
             // Update edge positions when node collapses/expands.

--- a/lynxkite-app/web/src/workspace/nodes/LynxKiteNode.tsx
+++ b/lynxkite-app/web/src/workspace/nodes/LynxKiteNode.tsx
@@ -184,6 +184,7 @@ function LynxKiteNodeComponent(props: LynxKiteNodeProps) {
   function setNewOpId(newOpId: string) {
     reactFlow.updateNodeData(props.id, {
       op_id: newOpId,
+      error: undefined,
     });
   }
   const height = Math.max(67, node?.height ?? props.height ?? 200);
@@ -315,9 +316,15 @@ function UnknownOperationNode(props: { op_id: string; onChange: (newName: string
     categoryHierarchy && (
       <div className="node-search" style={{ overflowY: "auto" }}>
         <div style={{ marginBottom: 20 }}>
-          "{props.op_id}" is not a known box. You may need to install an extension, or fix an issue
-          with a code file that defined it. Or perhaps the box has a new name. You can choose a
-          replacement from the list below:
+          {props.op_id ? (
+            <>
+              "{props.op_id}" is not a known box. You may need to install an extension, or fix an
+              issue with a code file that defined it. Or perhaps the box has a new name. You can
+              choose a replacement from the list below:
+            </>
+          ) : (
+            <>Choose a replacement from the list below:</>
+          )}
         </div>
         <NodeSearchInternal
           onCancel={() => {}}

--- a/lynxkite-graph-analytics/src/lynxkite_graph_analytics/core.py
+++ b/lynxkite-graph-analytics/src/lynxkite_graph_analytics/core.py
@@ -312,7 +312,7 @@ async def _execute_node(
     params = {**node.data.params}
     op = catalog.get(node.data.op_id)
     if not op:
-        node.publish_error("Operation not found in catalog")
+        node.publish_error("Unknown operation.")
         return
     node.publish_started()
     input_map = {}

--- a/lynxkite-graph-analytics/tests/test_lynxkite_ops.py
+++ b/lynxkite-graph-analytics/tests/test_lynxkite_ops.py
@@ -16,7 +16,7 @@ async def test_execute_operation_not_in_catalog():
         position=workspace.Position(x=0, y=0),
     )
     await execute(ws)
-    assert ws.nodes[0].data.error == "Operation not found in catalog"
+    assert ws.nodes[0].data.error == "Unknown operation."
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Follow-up for #100. It works. But I see an issue sometimes. After you choose a new box type, sometimes we see the "Unknown operation" error message with the new box type. That's quite confusing, because you just chose a box type, say "SQL", and then see "SQL is not a known box". I've added code to clear the error field, but it somehow comes back. Will need to investigate a bit more.

I also tweaked the toolbar button behavior a bit. I think it's simpler this way. They get disabled/enabled instead of appearing and disappearing.