### PR TITLE
TableColumn parameter type

### DIFF
--- a/lynxkite-app/web/src/index.css
+++ b/lynxkite-app/web/src/index.css
@@ -301,6 +301,21 @@ svg {
       select {
         border-color: oklch(90% 0 0);
       }
+
+      .double-dropdown {
+        display: flex;
+
+        .double-dropdown-first {
+          border-top-right-radius: 0;
+          border-bottom-right-radius: 0;
+        }
+
+        .double-dropdown-second {
+          border-top-left-radius: 0;
+          border-bottom-left-radius: 0;
+          margin-left: -1px;
+        }
+      }
     }
 
     .param-name-row {

--- a/lynxkite-core/src/lynxkite_core/ops.py
+++ b/lynxkite-core/src/lynxkite_core/ops.py
@@ -49,7 +49,7 @@ Type = typing.Annotated[typing.Any, pydantic.PlainSerializer(type_to_json, retur
 LongStr = typing.Annotated[str, {"format": "textarea"}]
 """LongStr is a string type for parameters that will be displayed as a multiline text area in the UI."""
 PathStr = typing.Annotated[str, {"format": "path"}]
-# https://github.com/python/typing/issues/182#issuecomment-1320974824
+# JSON type from https://github.com/python/typing/issues/182#issuecomment-1320974824.
 ReadOnlyJSON: typing.TypeAlias = (
     typing.Mapping[str, "ReadOnlyJSON"]
     | typing.Sequence["ReadOnlyJSON"]

--- a/lynxkite-graph-analytics/src/lynxkite_graph_analytics/core.py
+++ b/lynxkite-graph-analytics/src/lynxkite_graph_analytics/core.py
@@ -58,6 +58,19 @@ ColumnNameByTableName = typing.Annotated[
 rendered as a dropdown in the frontend, listing the columns of the DataFrame
 named by the "table_name" parameter. The column name is passed to the operation as a string."""
 
+TableColumn = typing.Annotated[
+    tuple[str, str],
+    {
+        "format": "double-dropdown",
+        "metadata_query1": "[].dataframes[].keys(@)[]",
+        "metadata_query2": "[].dataframes[].<first>.columns[]",
+    },
+]
+"""A type annotation to be used for parameters of an operation. TableColumn is
+rendered as a pair of dropdowns for selecting a table in the Bundle and a column inside of
+that table. Effectively "TableName" and "ColumnNameByTableName" combined.
+The selected table and column name is passed to the operation as a 2-tuple of strings."""
+
 
 @dataclasses.dataclass
 class RelationDefinition:


### PR DESCRIPTION
Resolves https://github.com/biggraph/lynxkite-2000-enterprise/issues/271.

I've tested it with:

```python
@op("LynxKite Graph Analytics", "Delete column")
def delete_column(b: Bundle, *, column: TableColumn) -> Bundle:
    """Deletes a column from a table.

    Args:
        b: Input bundle containing the table.
        column: The column to delete.
    """
    table, column = column
    b = b.copy()
    b.dfs[table] = b.dfs[table].drop(columns=[column])
    return b
```

<img width="1355" height="445" alt="image" src="https://github.com/user-attachments/assets/60060139-d600-4b9b-88df-95a1302ef5a8" />

The hard part comes next: changing all the existing operations to use this, then changing all the saved workspaces. :weary: 

First let's see if everyone likes it.