### PR TITLE
Fix "uninitialized nodes" warning

### DIFF
--- a/lynxkite-app/web/src/workspace/crdt.ts
+++ b/lynxkite-app/web/src/workspace/crdt.ts
@@ -248,20 +248,19 @@ class CRDTConnection {
     const ws = this.ws.toJSON() as WorkspaceType;
     if (!ws.nodes) return;
     if (!ws.edges) return;
-    const oldNodes = this.state?.feNodes || [];
-    const selection = new Set(oldNodes.filter((n) => n.selected).map((n) => n.id));
+    // Maintain ReactFlow properties on the nodes even as they pass through CRDT.
+    const oldNodes = Object.fromEntries(this.state?.feNodes.map((n) => [n.id, n]) || []);
+    const newNodes = [];
     for (const n of ws.nodes) {
       if (n.type !== "node_group") {
         n.dragHandle = ".drag-handle";
       }
-      if (selection.has(n.id)) {
-        n.selected = true;
-      }
+      newNodes.push({ ...oldNodes[n.id], ...n });
     }
     this.state = {
       ...this.state,
       ws,
-      feNodes: ws.nodes as Node[],
+      feNodes: newNodes as Node[],
       feEdges: ws.edges as Edge[],
     };
     this.notifyObservers();


### PR DESCRIPTION
Fixes #117. It's more copying this way, so maybe it's bad for performance. Though surely recomputing the sizes was also bad. I'll figure out the performance in #122.