### PR TITLE
Use new SPDX license specification field

### DIFF
--- a/lynxkite-app/pyproject.toml
+++ b/lynxkite-app/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "sse-starlette>=2.2.1",
     "uvicorn>=0.35.0",
 ]
-classifiers = ["License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)"]
+license = "AGPL-3.0-or-later"
 
 [project.urls]
 Homepage = "https://github.com/lynxkite/lynxkite-2000/"

--- a/lynxkite-core/pyproject.toml
+++ b/lynxkite-core/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
     "pydantic>=2.11.7",
 ]
-classifiers = ["License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)"]
+license = "AGPL-3.0-or-later"
 
 [project.urls]
 Homepage = "https://github.com/lynxkite/lynxkite-2000/"

--- a/lynxkite-graph-analytics/pyproject.toml
+++ b/lynxkite-graph-analytics/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "umap-learn>=0.5.9.post2",
     "pykeen>=1.11.1"
 ]
-classifiers = ["License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)"]
+license = "AGPL-3.0-or-later"
 
 [project.urls]
 Homepage = "https://github.com/lynxkite/lynxkite-2000/"

--- a/lynxkite-mcp/pyproject.toml
+++ b/lynxkite-mcp/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "lynxkite-core",
     "mcp>=1.20.0",
 ]
-classifiers = ["License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)"]
+license = "AGPL-3.0-or-later"
 
 [project.urls]
 Homepage = "https://github.com/lynxkite/lynxkite-2000/"

--- a/lynxkite-pillow-example/pyproject.toml
+++ b/lynxkite-pillow-example/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "lynxkite-core",
     "pillow>=11.1.0",
 ]
-classifiers = ["License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)"]
+license = "AGPL-3.0-or-later"
 
 [project.urls]
 Homepage = "https://github.com/lynxkite/lynxkite-2000/"

--- a/lynxkite/pyproject.toml
+++ b/lynxkite/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "lynxkite-app",
     "lynxkite-graph-analytics",
 ]
-classifiers = ["License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)"]
+license = "AGPL-3.0-or-later"
 
 [project.urls]
 Homepage = "https://github.com/lynxkite/lynxkite-2000/"


### PR DESCRIPTION
Same license, just using the new configuration described in https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license.

I've tested the 0.3.0 release and it seems to work!