### PR TITLE
Fix SEGFAULTs when interacting with deleted nodes.

### DIFF
--- a/lynxkite-app/src/lynxkite_app/crdt.py
+++ b/lynxkite-app/src/lynxkite_app/crdt.py
@@ -288,10 +288,10 @@ async def workspace_changed(name: str, changes: list[pycrdt.MapEvent], ws_crdt: 
     if ws_simple == last_known_versions.get(name):
         return
     last_known_versions[name] = ws_simple
-    # Frontend changes that result from typing are delayed to avoid
-    # rerunning the workspace for every keystroke.
     if name in delayed_executions:
         delayed_executions[name].cancel()
+    # Frontend changes that result from typing are delayed to avoid
+    # rerunning the workspace for every keystroke.
     delay = max(
         getattr(change, "keys", {}).get("__execution_delay", {}).get("newValue", 0) or 0
         for change in changes
@@ -299,11 +299,16 @@ async def workspace_changed(name: str, changes: list[pycrdt.MapEvent], ws_crdt: 
     # Check if workspace is paused - if so, skip automatic execution
     if getattr(ws_pyd, "paused", False):
         return
-    if delay:
-        task = asyncio.create_task(execute(name, ws_crdt, ws_pyd, delay=delay))
-        delayed_executions[name] = task
-    else:
-        await execute(name, ws_crdt, ws_pyd)
+
+    task = asyncio.create_task(execute(name, ws_crdt, ws_pyd, delay=delay))
+    delayed_executions[name] = task
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    finally:
+        if delayed_executions.get(name) is task:
+            del delayed_executions[name]
 
 
 async def execute(name: str, ws_crdt: pycrdt.Map, ws_pyd: workspace.Workspace, *, delay: int = 0):
@@ -317,10 +322,7 @@ async def execute(name: str, ws_crdt: pycrdt.Map, ws_pyd: workspace.Workspace, *
         delay: Wait time before executing the workspace. The default is 0.
     """
     if delay:
-        try:
-            await asyncio.sleep(delay)
-        except asyncio.CancelledError:
-            return
+        await asyncio.sleep(delay)
     print(f"Running {name} in {ws_pyd.env}...")
     cwd = pathlib.Path()
     path = cwd / name

--- a/lynxkite-core/src/lynxkite_core/workspace.py
+++ b/lynxkite-core/src/lynxkite_core/workspace.py
@@ -77,11 +77,14 @@ class WorkspaceNode(BaseConfig):
         self.data.error = None
         self.data.message = None
         self.data.status = NodeStatus.active
-        if self._crdt and "data" in self._crdt:
-            with self._crdt.doc.transaction():
-                self._crdt["data"]["error"] = None
-                self._crdt["data"]["message"] = None
-                self._crdt["data"]["status"] = NodeStatus.active
+        if self._crdt and "data" in getattr(self._crdt, "keys", lambda: [])():
+            try:
+                with self._crdt.doc.transaction():
+                    self._crdt["data"]["error"] = None
+                    self._crdt["data"]["message"] = None
+                    self._crdt["data"]["status"] = NodeStatus.active
+            except Exception:
+                pass  # Node might have been deleted
 
     def publish_result(self, result: ops.Result):
         """Sends the result to the frontend. Call this in an executor when the result is available."""
@@ -89,23 +92,25 @@ class WorkspaceNode(BaseConfig):
         self.data.input_metadata = result.input_metadata
         self.data.error = result.error
         self.data.status = NodeStatus.done
-        if self._crdt and "data" in self._crdt:
-            with self._crdt.doc.transaction():
-                try:
+        if self._crdt and "data" in getattr(self._crdt, "keys", lambda: [])():
+            try:
+                with self._crdt.doc.transaction():
                     self._crdt["data"]["status"] = NodeStatus.done
                     self._crdt["data"]["display"] = self.data.display
                     self._crdt["data"]["input_metadata"] = self.data.input_metadata
                     self._crdt["data"]["error"] = self.data.error
-                except Exception as e:
-                    self._crdt["data"]["error"] = str(e)
-                    raise e
+            except Exception:
+                pass  # Node might have been deleted
 
     def publish_message(self, message: str):
         """Sends a message to the frontend. This can be used for progress updates."""
         self.data.message = message
-        if self._crdt and "data" in self._crdt:
-            with self._crdt.doc.transaction():
-                self._crdt["data"]["message"] = message
+        if self._crdt and "data" in getattr(self._crdt, "keys", lambda: [])():
+            try:
+                with self._crdt.doc.transaction():
+                    self._crdt["data"]["message"] = message
+            except Exception:
+                pass  # Node might have been deleted
 
     def publish_error(self, error: Exception | str | None):
         """Can be called with None to clear the error state."""
@@ -266,10 +271,19 @@ class Workspace(BaseConfig):
 
         self._crdt = ws_crdt
         with ws_crdt.doc.transaction():
-            for nc, np in zip(ws_crdt["nodes"], self.nodes):
-                if "data" not in nc:
-                    nc["data"] = pycrdt.Map()
-                np._crdt = nc
+            node_crdt_by_id = {
+                node_crdt["id"]: node_crdt
+                for node_crdt in ws_crdt.get("nodes", [])
+                if "id" in node_crdt
+            }
+            for node_python in self.nodes:
+                node_crdt = node_crdt_by_id.get(node_python.id)
+                if node_crdt is not None:
+                    if "data" not in node_crdt:
+                        node_crdt["data"] = pycrdt.Map()
+                    node_python._crdt = node_crdt
+                else:
+                    node_python._crdt = None
 
     def add_node(self, func=None, **kwargs):
         """For convenience in e.g. tests."""

--- a/lynxkite-core/src/lynxkite_core/workspace.py
+++ b/lynxkite-core/src/lynxkite_core/workspace.py
@@ -72,19 +72,32 @@ class WorkspaceNode(BaseConfig):
     height: Optional[float] = None
     _crdt: Optional["pycrdt.Map"] = None
 
+    def _find_crdt_node(self) -> "pycrdt.Map | None":
+        """Look up this node's CRDT Map fresh from the live workspace CRDT. We always walk the live
+        array to avoid holding a proxy to freed Rust memory after a node deletion.
+        """
+        ws_crdt = self._crdt
+        if ws_crdt is None:
+            return None
+        try:
+            for nc in ws_crdt.get("nodes", []):
+                if "id" in nc and nc["id"] == self.id:
+                    return nc
+        except Exception:
+            pass
+        return None
+
     def publish_started(self):
         """Notifies the frontend that work has started on this node."""
         self.data.error = None
         self.data.message = None
         self.data.status = NodeStatus.active
-        if self._crdt and "data" in getattr(self._crdt, "keys", lambda: [])():
-            try:
-                with self._crdt.doc.transaction():
-                    self._crdt["data"]["error"] = None
-                    self._crdt["data"]["message"] = None
-                    self._crdt["data"]["status"] = NodeStatus.active
-            except Exception:
-                pass  # Node might have been deleted
+        nc = self._find_crdt_node()
+        if nc is not None and "data" in nc:
+            with nc.doc.transaction():
+                nc["data"]["error"] = None
+                nc["data"]["message"] = None
+                nc["data"]["status"] = NodeStatus.active
 
     def publish_result(self, result: ops.Result):
         """Sends the result to the frontend. Call this in an executor when the result is available."""
@@ -92,25 +105,27 @@ class WorkspaceNode(BaseConfig):
         self.data.input_metadata = result.input_metadata
         self.data.error = result.error
         self.data.status = NodeStatus.done
-        if self._crdt and "data" in getattr(self._crdt, "keys", lambda: [])():
-            try:
-                with self._crdt.doc.transaction():
-                    self._crdt["data"]["status"] = NodeStatus.done
-                    self._crdt["data"]["display"] = self.data.display
-                    self._crdt["data"]["input_metadata"] = self.data.input_metadata
-                    self._crdt["data"]["error"] = self.data.error
-            except Exception:
-                pass  # Node might have been deleted
+        nc = self._find_crdt_node()
+        if nc is not None and "data" in nc:
+            with nc.doc.transaction():
+                try:
+                    nc["data"]["status"] = NodeStatus.done
+                    nc["data"]["display"] = self.data.display
+                    nc["data"]["input_metadata"] = self.data.input_metadata
+                    nc["data"]["error"] = self.data.error
+                except Exception as e:
+                    # This can fail when display contains unserializable data.
+                    # In that case, we still want to publish the error.
+                    nc["data"]["error"] = str(e)
+                    raise e
 
     def publish_message(self, message: str):
         """Sends a message to the frontend. This can be used for progress updates."""
         self.data.message = message
-        if self._crdt and "data" in getattr(self._crdt, "keys", lambda: [])():
-            try:
-                with self._crdt.doc.transaction():
-                    self._crdt["data"]["message"] = message
-            except Exception:
-                pass  # Node might have been deleted
+        nc = self._find_crdt_node()
+        if nc is not None and "data" in nc:
+            with nc.doc.transaction():
+                nc["data"]["message"] = message
 
     def publish_error(self, error: Exception | str | None):
         """Can be called with None to clear the error state."""
@@ -243,28 +258,29 @@ class Workspace(BaseConfig):
         for node in self.nodes:
             data = node.data
             op = catalog.get(data.op_id)
+            nc = node._find_crdt_node()
             if op:
                 if getattr(data, "meta", None) != op:
                     data.meta = op
                     # If the node is connected to a CRDT, update that too.
-                    if node._crdt:
-                        node._crdt["data"]["meta"] = op.model_dump()
+                    if nc:
+                        nc["data"]["meta"] = op.model_dump()
                 if node.type != op.type:
                     node.type = op.type
-                    if node._crdt:
-                        node._crdt["type"] = op.type
+                    if nc:
+                        nc["type"] = op.type
                 if data.error == "Unknown operation.":
                     data.error = None
-                    if node._crdt:
-                        node._crdt["data"]["error"] = None
+                    if nc:
+                        nc["data"]["error"] = None
             else:
                 data.error = "Unknown operation."
                 data.meta = ops.Op.placeholder_from_id(data.op_id)
-                if node._crdt:
+                if nc:
                     import pycrdt
 
-                    node._crdt["data"]["meta"] = pycrdt.Map(data.meta.model_dump())
-                    node._crdt["data"]["error"] = "Unknown operation."
+                    nc["data"]["meta"] = pycrdt.Map(data.meta.model_dump())
+                    nc["data"]["error"] = "Unknown operation."
 
     def connect_crdt(self, ws_crdt: "pycrdt.Map"):
         import pycrdt
@@ -281,9 +297,9 @@ class Workspace(BaseConfig):
                 if node_crdt is not None:
                     if "data" not in node_crdt:
                         node_crdt["data"] = pycrdt.Map()
-                    node_python._crdt = node_crdt
-                else:
-                    node_python._crdt = None
+                # Store the workspace-level CRDT, not the node-level proxy.
+                # _find_crdt_node() will look up the node fresh each time.
+                node_python._crdt = ws_crdt
 
     def add_node(self, func=None, **kwargs):
         """For convenience in e.g. tests."""

--- a/lynxkite-core/src/lynxkite_core/workspace.py
+++ b/lynxkite-core/src/lynxkite_core/workspace.py
@@ -128,9 +128,10 @@ class WorkspaceNode(BaseConfig):
     def publish_telemetry(self, telemetry: dict[str, Any]):
         """Sends telemetry data to the frontend."""
         self.data.telemetry = telemetry
-        if self._crdt and "data" in self._crdt:
-            with self._crdt.doc.transaction():
-                self._crdt["data"]["telemetry"] = telemetry
+        nc = self._find_crdt_node()
+        if nc is not None and "data" in nc:
+            with nc.doc.transaction():
+                nc["data"]["telemetry"] = telemetry
 
     def publish_error(self, error: Exception | str | None):
         """Can be called with None to clear the error state."""

--- a/lynxkite-core/src/lynxkite_core/workspace.py
+++ b/lynxkite-core/src/lynxkite_core/workspace.py
@@ -70,21 +70,18 @@ class WorkspaceNode(BaseConfig):
     position: Position
     width: Optional[float] = None
     height: Optional[float] = None
-    _crdt: Optional["pycrdt.Map"] = None
+    _ws_crdt: Optional["pycrdt.Map"] = None
 
     def _find_crdt_node(self) -> "pycrdt.Map | None":
         """Look up this node's CRDT Map fresh from the live workspace CRDT. We always walk the live
         array to avoid holding a proxy to freed Rust memory after a node deletion.
         """
-        ws_crdt = self._crdt
+        ws_crdt: Optional["pycrdt.Map"] = self._ws_crdt
         if ws_crdt is None:
             return None
-        try:
-            for nc in ws_crdt.get("nodes", []):
-                if "id" in nc and nc["id"] == self.id:
-                    return nc
-        except Exception:
-            pass
+        for nc in ws_crdt.get("nodes", []):
+            if "id" in nc and nc["id"] == self.id:
+                return nc
         return None
 
     def publish_started(self):
@@ -297,9 +294,7 @@ class Workspace(BaseConfig):
                 if node_crdt is not None:
                     if "data" not in node_crdt:
                         node_crdt["data"] = pycrdt.Map()
-                # Store the workspace-level CRDT, not the node-level proxy.
-                # _find_crdt_node() will look up the node fresh each time.
-                node_python._crdt = ws_crdt
+                node_python._ws_crdt = ws_crdt
 
     def add_node(self, func=None, **kwargs):
         """For convenience in e.g. tests."""


### PR DESCRIPTION
I came across an interesting bug while stress-testing. I had a bunch of boxes and started slowly deleting them while the workspace was still running. Everything was working fine but sometimes I would run into the backend crashing with segmentation faults.

I traced it down with `python -X faulthandler` (very useful!) to the python backend communicating with the rust pycrdt map we have of the workspace nodes. Caused by stale memory pointers across asynchronous UI/backend interactions. Any await during an op execution makes it vulnerable to deletion-induced segfaults if the backend receives a delete event while waiting.

The root cause is that each `WorkspaceNode` was caching a direct `pycrdt.Map` proxy to its own node entry in the CRDT array. When the frontend deletes a node, the underlying Rust memory for that proxy is freed. However, when the still-running backend op finishes and calls `publish_result()` or `publish_started()`, it still holds that old proxy and attempts to write to freed memory, crashing the process.

The fix is to never hold onto node-level CRDT proxies. Instead, `node._crdt` now stores the long-lived workspace-level CRDT map, and a `_find_crdt_node()` method does a fresh lookup by node ID each time a publish call needs to write. If the node was deleted in the meantime, the lookup simply returns `None` and the write is skipped safely.

With this PR we should also cancel any stale execution correctly.