### PR TITLE
Grouping fixes and selection and dimension consistency

### DIFF
--- a/lynxkite-app/web/src/workspace/Workspace.tsx
+++ b/lynxkite-app/web/src/workspace/Workspace.tsx
@@ -418,7 +418,6 @@ function LynxKiteFlow() {
       width: 0,
       height: 0,
       data: { title: "Group", params: {} },
-      selected: true,
     };
     let top = Number.POSITIVE_INFINITY;
     let left = Number.POSITIVE_INFINITY;
@@ -453,10 +452,13 @@ function LynxKiteFlow() {
           });
           node.set("parentId", groupNode.id);
           node.set("extent", "parent");
-          node.set("selected", false);
         }
       }
     });
+    crdt.onFENodesChange?.([
+      ...selectedNodes.map((n) => ({ id: n.id, type: "select" as const, selected: false })),
+      { id: groupNode.id, type: "select" as const, selected: true },
+    ]);
   }
   function ungroupSelection() {
     const groups = Object.fromEntries(
@@ -464,8 +466,9 @@ function LynxKiteFlow() {
         .filter((n) => n.selected && n.type === "node_group" && !n.parentId)
         .map((n) => [n.id, n]),
     );
+    const childNodeIds = nodes.filter((n) => n.parentId && n.parentId in groups).map((n) => n.id);
     crdt.applyChange((conn) => {
-      const wnodes = conn.ws.get("nodes") as YArray<any>;
+      const wnodes = conn.ws.get("nodes") as YArray<YMap<any>>;
       for (const node of wnodes) {
         const g = groups[node.get("parentId") as string];
         if (!g) continue;
@@ -474,9 +477,8 @@ function LynxKiteFlow() {
           x: pos.x + g.position.x,
           y: pos.y + g.position.y,
         });
-        node.set("parentId", undefined);
-        node.set("extent", undefined);
-        node.set("selected", true);
+        node.delete("parentId");
+        node.delete("extent");
       }
       const groupIndices: number[] = wnodes
         .map((n: any, idx: number) => ({ id: n.get("id"), idx }))
@@ -487,6 +489,9 @@ function LynxKiteFlow() {
         wnodes.delete(groupIdx, 1);
       }
     });
+    crdt.onFENodesChange?.(
+      childNodeIds.map((id) => ({ id, type: "select" as const, selected: true })),
+    );
   }
   const selected = nodes.filter((n) => n.selected);
   const isAnyGroupSelected = nodes.some((n) => n.selected && n.type === "node_group");

--- a/lynxkite-app/web/src/workspace/crdt.ts
+++ b/lynxkite-app/web/src/workspace/crdt.ts
@@ -290,6 +290,24 @@ class CRDTConnection {
         n.dragHandle = ".drag-handle";
       }
       const mergedNode = { ...oldNodes[n.id], ...n };
+
+      // Clean up parent-child properties that may be stale from the old ReactFlow node.
+      if (!("parentId" in n)) {
+        delete mergedNode.parentId;
+      }
+      if (!("extent" in n)) {
+        delete mergedNode.extent;
+      }
+
+      if (
+        n.width != null &&
+        n.height != null &&
+        (oldNodes[n.id]?.measured?.width !== n.width ||
+          oldNodes[n.id]?.measured?.height !== n.height)
+      ) {
+        mergedNode.measured = { width: n.width, height: n.height };
+      }
+
       newNodes.push(mergedNode);
       if (needsNodeInternalsUpdate(oldNodes[n.id], mergedNode)) {
         changedNodeIds.push(n.id);

--- a/lynxkite-app/web/src/workspace/crdt.ts
+++ b/lynxkite-app/web/src/workspace/crdt.ts
@@ -292,10 +292,10 @@ class CRDTConnection {
       const mergedNode = { ...oldNodes[n.id], ...n };
 
       // Clean up parent-child properties that may be stale from the old ReactFlow node.
-      if (!("parentId" in n)) {
+      if (n.parentId === undefined) {
         delete mergedNode.parentId;
       }
-      if (!("extent" in n)) {
+      if (n.extent === undefined) {
         delete mergedNode.extent;
       }
 


### PR DESCRIPTION
I was messing around with grouping and ungrouping boxes, and had the same workspace open on two separate windows (to simulate collaborative working) and noticed that when grouping and ungrouping boxes the selections would show on every client. Another issue that I saw was that the box width was not being properly communicated, and would stay fixed on other clients (locally it worked fine).

This PR localizes selections to each client, calculates dimensions properly, and also fixes a long-standing bug where we dealt with `extent` and `parentId` improperly (#81). Now they are correctly deleted when the group ceases to exist.

This is in preparation for the undo/redo feature as undoing a group creation would lead to the console being spammed with errors. (Mainly because of `extent` and `parentId` being set incorrectly)