### PR TITLE
Implements undo functionality

### DIFF
--- a/lynxkite-app/web/src/workspace/Workspace.tsx
+++ b/lynxkite-app/web/src/workspace/Workspace.tsx
@@ -527,6 +527,7 @@ function LynxKiteFlow() {
                   className="btn btn-link"
                   disabled={selected.length < 2}
                   onClick={groupSelection}
+                  name="groupBtn"
                 >
                   <GroupIcon />
                 </button>
@@ -536,6 +537,7 @@ function LynxKiteFlow() {
                   className="btn btn-link"
                   disabled={!isAnyGroupSelected}
                   onClick={ungroupSelection}
+                  name="ungroupBtn"
                 >
                   <UngroupIcon />
                 </button>

--- a/lynxkite-app/web/src/workspace/Workspace.tsx
+++ b/lynxkite-app/web/src/workspace/Workspace.tsx
@@ -169,16 +169,23 @@ function LynxKiteFlow() {
       } else if (event.key === "r") {
         event.preventDefault();
         executeWorkspace();
-      } else if (isPrimaryModifierPressed && !(nodeSearchSettings || isTypingInFormElement())) {
-        if (event.key.toLowerCase() === "c") {
-          copySelection(nodes, edges, crdt?.ws ?? {});
-        } else if (event.key.toLowerCase() === "v") {
-          pasteSelection(crdt, cursorScreenPos, reactFlow, setMessage);
-        } else if (event.key.toLowerCase() === "x") {
-          cutSelection(nodes, edges, crdt?.ws ?? {}, deleteSelection);
-        } else if (event.key.toLowerCase() === "a") {
-          event.preventDefault();
-          selectAll();
+      } else if (isPrimaryModifierPressed) {
+        if (event.key === "z") {
+          crdt?.undo();
+        } else if (event.key === "y") {
+          crdt?.redo();
+        } else if (!(nodeSearchSettings || isTypingInFormElement())) {
+          const key = event.key.toLowerCase();
+          if (key === "c") {
+            copySelection(nodes, edges, crdt?.ws ?? {});
+          } else if (key === "v") {
+            pasteSelection(crdt, cursorScreenPos, reactFlow, setMessage);
+          } else if (key === "x") {
+            cutSelection(nodes, edges, crdt?.ws ?? {}, deleteSelection);
+          } else if (key === "a") {
+            event.preventDefault();
+            selectAll();
+          }
         }
       }
     };

--- a/lynxkite-app/web/src/workspace/crdt.ts
+++ b/lynxkite-app/web/src/workspace/crdt.ts
@@ -52,6 +52,8 @@ type CRDTWorkspace = {
   addEdge: (edge: Partial<WorkspaceEdge>) => void;
   onFENodesChange?: (changes: any[]) => void;
   onFEEdgesChange?: (changes: any[]) => void;
+  undo: () => void;
+  redo: () => void;
 };
 
 export function nodeToYMap(node: any): Y.Map<WorkspaceNode> {
@@ -78,6 +80,7 @@ export function nodeToYMap(node: any): Y.Map<WorkspaceNode> {
 class CRDTConnection {
   doc: Y.Doc;
   ws: Y.Map<any>;
+  undoManager: Y.UndoManager;
   wsProvider: WebsocketProvider;
   reactFlow: ReturnType<typeof useReactFlow>;
   updateNodeInternals: (id: string) => void;
@@ -91,6 +94,7 @@ class CRDTConnection {
     this.reactFlow = reactFlow;
     this.updateNodeInternals = updateNodeInternals;
     this.doc = new Y.Doc();
+    this.undoManager = new Y.UndoManager(this.doc, { captureTimeout: 600 });
     this.ws = this.doc.getMap("workspace");
     const proto = location.protocol === "https:" ? "wss:" : "ws:";
     const encodedPath = path!
@@ -143,6 +147,14 @@ class CRDTConnection {
         this.doc.transact(() => {
           fn(this);
         });
+        this.updateState();
+      },
+      undo: () => {
+        this.undoManager.undo();
+        this.updateState();
+      },
+      redo: () => {
+        this.undoManager.redo();
         this.updateState();
       },
     };

--- a/lynxkite-app/web/tests/lynxkite.ts
+++ b/lynxkite-app/web/tests/lynxkite.ts
@@ -50,6 +50,23 @@ export class Workspace {
     await this.page.locator('button[name="ungroupBtn"]').click();
   }
 
+  async getNodeParentId(nodeId: string): Promise<string | undefined> {
+    return this.page.evaluate((id) => {
+      const el = document.querySelector(`[data-id="${CSS.escape(id)}"]`);
+      if (!el) return undefined;
+      const key = Object.keys(el).find((k) => k.startsWith("__reactFiber$"));
+      if (!key) return undefined;
+      let fiber = (el as any)[key];
+      while (fiber) {
+        if (fiber.memoizedProps?.id === id && "parentId" in fiber.memoizedProps) {
+          return fiber.memoizedProps.parentId || undefined;
+        }
+        fiber = fiber.child;
+      }
+      return undefined;
+    }, nodeId);
+  }
+
   async expectCurrentWorkspaceIs(name) {
     await expect(this.page.locator(".ws-name")).toHaveText(name);
   }

--- a/lynxkite-app/web/tests/lynxkite.ts
+++ b/lynxkite-app/web/tests/lynxkite.ts
@@ -42,6 +42,14 @@ export class Workspace {
     await this.page.locator('select[name="workspace-env"]').selectOption(env);
   }
 
+  async groupSelection() {
+    await this.page.locator('button[name="groupBtn"]').click();
+  }
+
+  async ungroupSelection() {
+    await this.page.locator('button[name="ungroupBtn"]').click();
+  }
+
   async expectCurrentWorkspaceIs(name) {
     await expect(this.page.locator(".ws-name")).toHaveText(name);
   }

--- a/lynxkite-app/web/tests/undo_redo.spec.ts
+++ b/lynxkite-app/web/tests/undo_redo.spec.ts
@@ -45,16 +45,16 @@ test("undo/redo box dragging", async () => {
   await new Promise((resolve) => setTimeout(resolve, 600));
   await workspace.moveBox("Import Parquet 1", { offsetX: 100, offsetY: 100 });
   const newPos = await workspace.getBox("Import Parquet 1").boundingBox();
-  expect(newPos?.x).toBeGreaterThan(originalPos?.x);
-  expect(newPos?.y).toBeGreaterThan(originalPos?.y);
+  expect(newPos?.x).toBeGreaterThan(originalPos!.x);
+  expect(newPos?.y).toBeGreaterThan(originalPos!.y);
   await workspace.page.keyboard.press("Control+z");
   const undonePos = await workspace.getBox("Import Parquet 1").boundingBox();
-  expect(undonePos?.x).toBeCloseTo(originalPos?.x, 1);
-  expect(undonePos?.y).toBeCloseTo(originalPos?.y, 1);
+  expect(undonePos?.x).toBeCloseTo(originalPos!.x, 1);
+  expect(undonePos?.y).toBeCloseTo(originalPos!.y, 1);
   await workspace.page.keyboard.press("Control+y");
   const redonePos = await workspace.getBox("Import Parquet 1").boundingBox();
-  expect(redonePos?.x).toBeGreaterThan(originalPos?.x);
-  expect(redonePos?.y).toBeGreaterThan(originalPos?.y);
+  expect(redonePos?.x).toBeGreaterThan(originalPos!.x);
+  expect(redonePos?.y).toBeGreaterThan(originalPos!.y);
 });
 
 test("undo/redo grouping boxes", async () => {
@@ -70,23 +70,40 @@ test("undo/redo grouping boxes", async () => {
   await workspace.selectBoxes(["Import Parquet 1", "View tables 1"]);
   await new Promise((resolve) => setTimeout(resolve, 600));
   await workspace.groupSelection();
+  await expect(workspace.getBox("Group 1")).toBeVisible();
+  await expect(async () =>
+    expect(await workspace.getNodeParentId("Import Parquet 1")).toBe("Group 1"),
+  ).toPass();
+  await expect(async () =>
+    expect(await workspace.getNodeParentId("View tables 1")).toBe("Group 1"),
+  ).toPass();
+
   await workspace.page.keyboard.press("Control+z");
   await expect(workspace.getBox("Group 1")).not.toBeVisible();
   await expect(workspace.getBox("Import Parquet 1")).toBeVisible();
   await expect(workspace.getBox("View tables 1")).toBeVisible();
+  await expect(async () =>
+    expect(await workspace.getNodeParentId("Import Parquet 1")).toBeUndefined(),
+  ).toPass();
+  await expect(async () =>
+    expect(await workspace.getNodeParentId("View tables 1")).toBeUndefined(),
+  ).toPass();
   expect(consoleMessages).toEqual([]);
 
   await workspace.page.keyboard.press("Control+y");
   await expect(workspace.getBox("Group 1")).toBeVisible();
-  await expect(workspace.getBox("Group 1").locator('[data-id="Import Parquet 1"]')).toBeVisible();
-  await expect(workspace.getBox("Group 1").locator('[data-id="View tables 1"]')).toBeVisible();
+  await expect(async () =>
+    expect(await workspace.getNodeParentId("Import Parquet 1")).toBe("Group 1"),
+  ).toPass();
+  await expect(async () =>
+    expect(await workspace.getNodeParentId("View tables 1")).toBe("Group 1"),
+  ).toPass();
   expect(consoleMessages).toEqual([]);
 });
 
 test("undo/redo normal text input", async () => {
   await workspace.addBox("NetworkX › Generators › Directed › Scale-free graph");
   const graphBox = workspace.getBox("Scale-free graph 1");
-  await new Promise((resolve) => setTimeout(resolve, 600));
   await graphBox.getByLabel("n", { exact: true }).fill("10");
   await workspace.page.keyboard.press("Control+z");
   await expect(graphBox.getByLabel("n", { exact: true })).toHaveValue("");

--- a/lynxkite-app/web/tests/undo_redo.spec.ts
+++ b/lynxkite-app/web/tests/undo_redo.spec.ts
@@ -29,6 +29,7 @@ test("undo/redo add_node transaction", async () => {
 test("undo/redo add_edge transaction", async () => {
   await workspace.addBox("Graph embedding and link prediction › Import PyKEEN dataset");
   await workspace.addBox("View tables");
+  await new Promise((resolve) => setTimeout(resolve, 600));
   await workspace.connectBoxes("Import PyKEEN dataset 1", "View tables 1");
   const tableBox = workspace.getBox("View tables 1");
   await expect(tableBox.locator(".error")).not.toBeVisible();
@@ -41,18 +42,19 @@ test("undo/redo add_edge transaction", async () => {
 test("undo/redo box dragging", async () => {
   await workspace.addBox("Import Parquet");
   const originalPos = await workspace.getBox("Import Parquet 1").boundingBox();
+  await new Promise((resolve) => setTimeout(resolve, 600));
   await workspace.moveBox("Import Parquet 1", { offsetX: 100, offsetY: 100 });
   const newPos = await workspace.getBox("Import Parquet 1").boundingBox();
-  expect(newPos?.x).toBeGreaterThan(originalPos?.x || 0);
-  expect(newPos?.y).toBeGreaterThan(originalPos?.y || 0);
+  expect(newPos?.x).toBeGreaterThan(originalPos?.x);
+  expect(newPos?.y).toBeGreaterThan(originalPos?.y);
   await workspace.page.keyboard.press("Control+z");
   const undonePos = await workspace.getBox("Import Parquet 1").boundingBox();
-  expect(undonePos?.x).toBeCloseTo(originalPos?.x || 0, 1);
-  expect(undonePos?.y).toBeCloseTo(originalPos?.y || 0, 1);
+  expect(undonePos?.x).toBeCloseTo(originalPos?.x, 1);
+  expect(undonePos?.y).toBeCloseTo(originalPos?.y, 1);
   await workspace.page.keyboard.press("Control+y");
   const redonePos = await workspace.getBox("Import Parquet 1").boundingBox();
-  expect(redonePos?.x).toBeGreaterThan(originalPos?.x || 0);
-  expect(redonePos?.y).toBeGreaterThan(originalPos?.y || 0);
+  expect(redonePos?.x).toBeGreaterThan(originalPos?.x);
+  expect(redonePos?.y).toBeGreaterThan(originalPos?.y);
 });
 
 test("undo/redo grouping boxes", async () => {
@@ -66,6 +68,7 @@ test("undo/redo grouping boxes", async () => {
   await workspace.addBox("View tables");
   await workspace.connectBoxes("Import Parquet 1", "View tables 1");
   await workspace.selectBoxes(["Import Parquet 1", "View tables 1"]);
+  await new Promise((resolve) => setTimeout(resolve, 600));
   await workspace.groupSelection();
   await workspace.page.keyboard.press("Control+z");
   await expect(workspace.getBox("Group 1")).not.toBeVisible();
@@ -83,6 +86,7 @@ test("undo/redo grouping boxes", async () => {
 test("undo/redo normal text input", async () => {
   await workspace.addBox("NetworkX › Generators › Directed › Scale-free graph");
   const graphBox = workspace.getBox("Scale-free graph 1");
+  await new Promise((resolve) => setTimeout(resolve, 600));
   await graphBox.getByLabel("n", { exact: true }).fill("10");
   await workspace.page.keyboard.press("Control+z");
   await expect(graphBox.getByLabel("n", { exact: true })).toHaveValue("");

--- a/lynxkite-app/web/tests/undo_redo.spec.ts
+++ b/lynxkite-app/web/tests/undo_redo.spec.ts
@@ -1,0 +1,91 @@
+// Tests undo/redo functionality
+import { expect, test } from "@playwright/test";
+import { Splash, Workspace } from "./lynxkite";
+
+let workspace: Workspace;
+
+test.beforeEach(async ({ browser }) => {
+  workspace = await Workspace.empty(await browser.newPage(), "undo_redo_spec_test");
+});
+
+test.afterEach(async () => {
+  await workspace.close();
+  const splash = await new Splash(workspace.page);
+  splash.page.on("dialog", async (dialog) => {
+    await dialog.accept();
+  });
+  await splash.deleteEntry("undo_redo_spec_test");
+});
+
+test("undo/redo add_node transaction", async () => {
+  await workspace.addBox("Import Parquet");
+  await expect(workspace.getBox("Import Parquet 1")).toBeVisible();
+  await workspace.page.keyboard.press("Control+z");
+  await expect(workspace.getBox("Import Parquet 1")).not.toBeVisible();
+  await workspace.page.keyboard.press("Control+y");
+  await expect(workspace.getBox("Import Parquet 1")).toBeVisible();
+});
+
+test("undo/redo add_edge transaction", async () => {
+  await workspace.addBox("Graph embedding and link prediction › Import PyKEEN dataset");
+  await workspace.addBox("View tables");
+  await workspace.connectBoxes("Import PyKEEN dataset 1", "View tables 1");
+  const tableBox = workspace.getBox("View tables 1");
+  await expect(tableBox.locator(".error")).not.toBeVisible();
+  await workspace.page.keyboard.press("Control+z");
+  await expect(tableBox.locator(".error")).toBeVisible();
+  await workspace.page.keyboard.press("Control+y");
+  await expect(tableBox.locator(".error")).not.toBeVisible();
+});
+
+test("undo/redo box dragging", async () => {
+  await workspace.addBox("Import Parquet");
+  const originalPos = await workspace.getBox("Import Parquet 1").boundingBox();
+  await workspace.moveBox("Import Parquet 1", { offsetX: 100, offsetY: 100 });
+  const newPos = await workspace.getBox("Import Parquet 1").boundingBox();
+  expect(newPos?.x).toBeGreaterThan(originalPos?.x || 0);
+  expect(newPos?.y).toBeGreaterThan(originalPos?.y || 0);
+  await workspace.page.keyboard.press("Control+z");
+  const undonePos = await workspace.getBox("Import Parquet 1").boundingBox();
+  expect(undonePos?.x).toBeCloseTo(originalPos?.x || 0, 1);
+  expect(undonePos?.y).toBeCloseTo(originalPos?.y || 0, 1);
+  await workspace.page.keyboard.press("Control+y");
+  const redonePos = await workspace.getBox("Import Parquet 1").boundingBox();
+  expect(redonePos?.x).toBeGreaterThan(originalPos?.x || 0);
+  expect(redonePos?.y).toBeGreaterThan(originalPos?.y || 0);
+});
+
+test("undo/redo grouping boxes", async () => {
+  const consoleMessages: { type: string; text: string }[] = [];
+  workspace.page.on("console", (msg) => {
+    if (msg.type() === "error" || msg.type() === "warning") {
+      consoleMessages.push({ type: msg.type(), text: msg.text() });
+    }
+  });
+  await workspace.addBox("Import Parquet");
+  await workspace.addBox("View tables");
+  await workspace.connectBoxes("Import Parquet 1", "View tables 1");
+  await workspace.selectBoxes(["Import Parquet 1", "View tables 1"]);
+  await workspace.groupSelection();
+  await workspace.page.keyboard.press("Control+z");
+  await expect(workspace.getBox("Group 1")).not.toBeVisible();
+  await expect(workspace.getBox("Import Parquet 1")).toBeVisible();
+  await expect(workspace.getBox("View tables 1")).toBeVisible();
+  expect(consoleMessages).toEqual([]);
+
+  await workspace.page.keyboard.press("Control+y");
+  await expect(workspace.getBox("Group 1")).toBeVisible();
+  await expect(workspace.getBox("Group 1").locator('[data-id="Import Parquet 1"]')).toBeVisible();
+  await expect(workspace.getBox("Group 1").locator('[data-id="View tables 1"]')).toBeVisible();
+  expect(consoleMessages).toEqual([]);
+});
+
+test("undo/redo normal text input", async () => {
+  await workspace.addBox("NetworkX › Generators › Directed › Scale-free graph");
+  const graphBox = workspace.getBox("Scale-free graph 1");
+  await graphBox.getByLabel("n", { exact: true }).fill("10");
+  await workspace.page.keyboard.press("Control+z");
+  await expect(graphBox.getByLabel("n", { exact: true })).toHaveValue("");
+  await workspace.page.keyboard.press("Control+y");
+  await expect(graphBox.getByLabel("n", { exact: true })).toHaveValue("10");
+});


### PR DESCRIPTION
This PR adds the ability to undo/redo actions (closes #115). The user is able to undo/redo their own changes, but only during the same session. This is probably the expected behavior we want.

We don't explicitly make use of the stored `crdt`, but with using [`Y.UndoManager`](https://docs.yjs.dev/api/undo-manager) we can get away with very little code changes and we get a lot of convenience. For example: we don't need to track what users did what, the `UndoManager` tracks it for us.