### PR TITLE
Fix: delete telemetry data to not trigger execution

### DIFF
--- a/lynxkite-app/src/lynxkite_app/crdt.py
+++ b/lynxkite-app/src/lynxkite_app/crdt.py
@@ -168,6 +168,7 @@ def clean_input(ws_pyd):
         node.data.input_metadata = None
         node.data.error = None
         node.data.message = None
+        node.data.telemetry = None
         node.data.collapsed = False
         node.data.expanded_height = 0
         node.data.status = workspace.NodeStatus.done


### PR DESCRIPTION
I found a bug when using `self.tqdm` inside a box: the execution reruns endlessly as something always triggers it. Deleting telemetry data inside `clean_input` is needed to not trigger executions endlessly.