### PR TITLE
Handle .cif file formats

### DIFF
--- a/lynxkite-app/web/src/workspace/Workspace.tsx
+++ b/lynxkite-app/web/src/workspace/Workspace.tsx
@@ -363,6 +363,8 @@ function LynxKiteFlow() {
         node.data!.params.file_format = "json";
       } else if (file.name.includes(".xls")) {
         node.data!.params.file_format = "excel";
+      } else if (file.name.includes(".cif")) {
+        node.data!.params.file_format = "cif";
       }
       addNode(node);
     } catch (error) {

--- a/lynxkite-graph-analytics/src/lynxkite_graph_analytics/operations/file_ops.py
+++ b/lynxkite-graph-analytics/src/lynxkite_graph_analytics/operations/file_ops.py
@@ -17,6 +17,7 @@ class FileFormat(enum.StrEnum):
     parquet = "parquet"
     json = "json"
     excel = "excel"
+    cif = "cif"
 
 
 @op(
@@ -35,6 +36,7 @@ class FileFormat(enum.StrEnum):
                 "parquet": [],
                 "json": [],
                 "excel": [ops.Parameter.basic("sheet_name", type=str, default="Sheet1")],
+                "cif": [],
             },
             default=FileFormat.csv,
         ),
@@ -67,6 +69,9 @@ def import_file(
         df = pd.read_parquet(file_path)
     elif file_format == "excel":
         df = pd.read_excel(file_path, sheet_name=kwargs.get("sheet_name", "Sheet1"))
+    elif file_format == "cif":
+        with open(file_path, "r") as f:
+            df = pd.DataFrame({"cif": [f.read()]})
     else:
         raise ValueError(f"Unsupported file format: {file_format}")
     return core.Bundle(dfs={table_name: df})


### PR DESCRIPTION
My attempt at #209
Copying large file contents into a box seems a bit inconvenient for me. Supporting .cif formats at drag-and-drop and in "Import file" box is much more intuitive but then what about a .pdb? Should we include that too? And there are also hundreds of other file formats that we can just read into a 1-row 1-column table.

(testing this with the View Molecule box was a headache as I only realized after too much debugging that not every .cif content can be visualized)