### PR TITLE
Do not let Mol* break scrolling in directory view

### DIFF
--- a/lynxkite-app/web/src/workspace/nodes/NodeWithMolecule.tsx
+++ b/lynxkite-app/web/src/workspace/nodes/NodeWithMolecule.tsx
@@ -47,6 +47,7 @@ const NodeWithMolecule = (props: any) => {
         container.innerHTML = "";
 
         const viewer = await Viewer.create(container, {
+          layoutIsExpanded: false,
           layoutShowControls: false,
           layoutShowRemoteState: false,
           layoutShowLog: false,


### PR DESCRIPTION
Repro: open a workspace with molecules, then close it and try to scroll the directory browser.