### PR TITLE
Fix sql example

### DIFF
--- a/examples/Basic examples/sql.lynxkite.json
+++ b/examples/Basic examples/sql.lynxkite.json
@@ -71,7 +71,7 @@
       "targetHandle": "graph"
     }
   ],
-  "env": "LynxKite",
+  "env": "LynxKite Graph Analytics",
   "nodes": [
     {
       "data": {

--- a/lynxkite-app/web/tests/examples.spec.ts
+++ b/lynxkite-app/web/tests/examples.spec.ts
@@ -24,7 +24,7 @@ for (const name of WORKSPACES) {
 
 test("Model use", async ({ page }) => {
   const ws = await openWorkspace(page, "Model use");
-  await ws.execute({ timeout: 30000 }); // Actually trains the model.
+  await ws.execute({ timeout: 60000 }); // Actually trains the model.
   await ws.expectErrorFree();
   let b = ws.boxByTitle("Train/test split");
   await b.expectParameterOptions("table name", ["", "records"]);


### PR DESCRIPTION
Fixes #248. Looks like it had a "LynxKite" env. Actually that may be a better name than "LynxKite Graph Analytics", but it's easier to fix this than to change that.