### PR TITLE
Correctly set timeout for "Model use" test

### DIFF
--- a/lynxkite-app/web/tests/examples.spec.ts
+++ b/lynxkite-app/web/tests/examples.spec.ts
@@ -23,6 +23,7 @@ for (const name of WORKSPACES) {
 }
 
 test("Model use", async ({ page }) => {
+  test.setTimeout(60000);
   const ws = await openWorkspace(page, "Model use");
   await ws.execute({ timeout: 60000 }); // Actually trains the model.
   await ws.expectErrorFree();


### PR DESCRIPTION
Sorry, the "fix" in #250 didn't cut it. It increased the timeout for the execution step, but the whole test also has a timeout that was 30 seconds. Let's try 60!