### PR TITLE
Simplify each node to just its icon when zoomed out

### DIFF
--- a/lynxkite-app/web/src/index.css
+++ b/lynxkite-app/web/src/index.css
@@ -372,6 +372,32 @@ svg {
     --status-color-3: #888f;
   }
 
+  .lynxkite-node.lynxkite-node-iconized {
+    .node-content {
+      display: none;
+    }
+
+    /* In the iconized view we fill the box with the tooltip handler, and center the icon inside it. */
+    div[data-tooltip-id] {
+      height: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+
+      .title-icon {
+        display: block;
+        width: 150px;
+        height: 150px;
+        color: white;
+      }
+
+      .title-icon-placeholder {
+        flex: none;
+        width: 0;
+      }
+    }
+  }
+
   .handle-name {
     font-size: 10px;
     color: black;

--- a/lynxkite-app/web/src/workspace/LynxKiteState.ts
+++ b/lynxkite-app/web/src/workspace/LynxKiteState.ts
@@ -1,4 +1,4 @@
 import { createContext } from "react";
 import type { Workspace } from "../apiTypes.ts";
 
-export const LynxKiteState = createContext({ workspace: {} as Workspace });
+export const LynxKiteState = createContext({ workspace: {} as Workspace, iconized: false });

--- a/lynxkite-app/web/src/workspace/Workspace.tsx
+++ b/lynxkite-app/web/src/workspace/Workspace.tsx
@@ -84,6 +84,8 @@ export default function Workspace(props: any) {
   );
 }
 
+const ICONIZE_THRESHOLD = 0.3;
+
 function LynxKiteFlow() {
   const reactFlow = useReactFlow();
   const reactFlowContainer = useRef<HTMLDivElement>(null);
@@ -95,6 +97,7 @@ function LynxKiteFlow() {
   );
   const path = usePath().replace(/^[/]edit[/]/, "");
   const [message, setMessage] = useState(null as string | null);
+  const [iconized, setIconized] = useState(reactFlow.getZoom() < ICONIZE_THRESHOLD);
   const shortPath = path!
     .split("/")
     .pop()!
@@ -646,7 +649,7 @@ function LynxKiteFlow() {
           ref={reactFlowContainer}
         >
           {crdt?.ws ? (
-            <LynxKiteState.Provider value={{ workspace: crdt.ws }}>
+            <LynxKiteState.Provider value={{ workspace: crdt.ws, iconized }}>
               <ReactFlow
                 nodes={nodes}
                 edges={autoConnect.renderedEdges}
@@ -666,6 +669,10 @@ function LynxKiteFlow() {
                 onConnect={onConnect}
                 onNodeDrag={autoConnect.onNodeDrag}
                 onNodeDragStop={autoConnect.onNodeDragStop}
+                onMove={() => {
+                  const zoom = reactFlow.getZoom();
+                  setIconized(zoom < ICONIZE_THRESHOLD);
+                }}
                 proOptions={{ hideAttribution: true }}
                 maxZoom={10}
                 minZoom={0.1}

--- a/lynxkite-app/web/src/workspace/nodes/LynxKiteNode.tsx
+++ b/lynxkite-app/web/src/workspace/nodes/LynxKiteNode.tsx
@@ -16,6 +16,7 @@ import { NodeProgress } from "./ProgressBar.tsx";
 
 interface LynxKiteNodeProps {
   id: string;
+  type: string;
   width: number;
   height: number;
   nodeStyle: any;
@@ -171,7 +172,9 @@ function LynxKiteNodeComponent(props: LynxKiteNodeProps) {
   const containerRef = React.useRef<HTMLDivElement>(null);
   const data = props.data;
   const state = useContext(LynxKiteState);
-  const iconized = state.iconized;
+  const canIconize =
+    !data.collapsed && !["visualization", "image", "molecule"].includes(props.type);
+  const iconized = state.iconized && canIconize;
   const handles = getHandles(
     state.workspace,
     props.id,

--- a/lynxkite-app/web/src/workspace/nodes/LynxKiteNode.tsx
+++ b/lynxkite-app/web/src/workspace/nodes/LynxKiteNode.tsx
@@ -1,6 +1,6 @@
 import { Handle, NodeResizeControl, type Position, useReactFlow } from "@xyflow/react";
 import Color from "colorjs.io";
-import React, { useContext } from "react";
+import React, { useContext, useMemo } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import AlertTriangle from "~icons/tabler/alert-triangle-filled.jsx";
 import ChevronDownRight from "~icons/tabler/chevron-down-right.jsx";
@@ -171,6 +171,7 @@ function LynxKiteNodeComponent(props: LynxKiteNodeProps) {
   const containerRef = React.useRef<HTMLDivElement>(null);
   const data = props.data;
   const state = useContext(LynxKiteState);
+  const iconized = state.iconized;
   const handles = getHandles(
     state.workspace,
     props.id,
@@ -212,6 +213,7 @@ function LynxKiteNodeComponent(props: LynxKiteNodeProps) {
   }
   const height = Math.max(67, node?.height ?? props.height ?? 315);
   const meta = data.meta ?? {};
+  const icon = useMemo(() => <Icon name={meta.icon} />, [meta.icon]);
   const summary: string = data.error
     ? `Error: ${data.error}`
     : (data.collapsed && paramSummary(data)) || docToString(meta.doc);
@@ -244,24 +246,33 @@ function LynxKiteNodeComponent(props: LynxKiteNodeProps) {
       }}
       ref={containerRef}
     >
-      <div className="lynxkite-node" style={nodeStyle}>
-        <Tooltip doc={titleTooltip} disabled={props.dragging}>
-          <div
-            style={titleStyle}
-            className={`title drag-handle ${data.status}`}
-            onClick={titleClicked}
-          >
-            <Icon name={meta.icon} />
-            <div className="title-right-side">
-              <div className="title-right-side-top">
-                <span className="title-title">{data.title}</span>
-                {data.error && <AlertTriangle />}
-                {data.collapsed && <Dots />}
+      <div
+        className={`lynxkite-node ${iconized ? "lynxkite-node-iconized" : ""}`}
+        style={iconized ? { ...nodeStyle, ...titleStyle } : nodeStyle}
+      >
+        {iconized ? (
+          <Tooltip doc={data.title} disabled={props.dragging}>
+            {icon}
+          </Tooltip>
+        ) : (
+          <Tooltip doc={titleTooltip} disabled={props.dragging}>
+            <div
+              style={titleStyle}
+              className={`title drag-handle ${data.status}`}
+              onClick={titleClicked}
+            >
+              {icon}
+              <div className="title-right-side">
+                <div className="title-right-side-top">
+                  <span className="title-title">{data.title}</span>
+                  {data.error && <AlertTriangle />}
+                  {data.collapsed && <Dots />}
+                </div>
+                {summary && <span className="title-summary">{summary}</span>}
               </div>
-              {summary && <span className="title-summary">{summary}</span>}
             </div>
-          </div>
-        </Tooltip>
+          </Tooltip>
+        )}
         {!data.collapsed && (
           <>
             <div className="node-content">


### PR DESCRIPTION
The change between the two modes results in a rerender of course, and on the example I used for testing (N16) that results in a significant stutter. Oddly, I don't see the same issue on other workspaces. Hopefully #120 will fix it! :sweat_smile: 

I tried memoizing the icon, but it didn't help. I've left it in anyway.

I tried removing `node-contents` from the DOM vs just hiding it. I saw no difference in performance. Hiding may be better for the user -- ephemeral state, like the rotation of a molecule in Mol*, will hopefully survive this way. So that's what I have in the PR now.

<img width="2376" height="1757" alt="image" src="https://github.com/user-attachments/assets/3ed277a3-91c5-4590-bf20-d2c3245e44a9" />
