### PR TITLE
Fix custom boxes being unknown

### DIFF
--- a/lynxkite-core/src/lynxkite_core/workspace.py
+++ b/lynxkite-core/src/lynxkite_core/workspace.py
@@ -249,6 +249,7 @@ class Workspace(BaseConfig):
         path = str(path)
         with open(path, encoding="utf-8") as f:
             j = f.read()
+        ops.load_user_scripts(path)
         ws = Workspace.model_validate_json(j)
         # Metadata is added after loading. This way code changes take effect on old boxes too.
         ws.update_metadata()

--- a/lynxkite-core/tests/test_workspace.py
+++ b/lynxkite-core/tests/test_workspace.py
@@ -1,7 +1,10 @@
 import os
+import pathlib
 import pytest
 import tempfile
-from lynxkite_core import workspace
+from lynxkite_core import workspace, ops
+
+ops.user_script_root = pathlib.Path(tempfile.gettempdir())
 
 
 def test_save_load():

--- a/lynxkite-core/tests/test_workspace.py
+++ b/lynxkite-core/tests/test_workspace.py
@@ -4,11 +4,11 @@ import pytest
 import tempfile
 from lynxkite_core import workspace, ops
 
-ops.user_script_root = pathlib.Path(tempfile.gettempdir())
+ENV = "test_workspace_env"
 
 
 def test_save_load():
-    ws = workspace.Workspace(env="test")
+    ws = workspace.Workspace(env=ENV)
     ws.add_node(
         id="1",
         type="node_type",
@@ -61,15 +61,21 @@ def test_save_load():
         os.remove(path)
 
 
-@pytest.fixture(scope="session", autouse=True)
-def populate_ops_catalog():
-    from lynxkite_core import ops
-
-    ops.register_passive_op("test", "Test Operation", inputs=[])
+@pytest.fixture(autouse=True)
+def isolate_ops_state():
+    old_user_script_root = ops.user_script_root
+    ops.save_catalogs("test_workspace")
+    ops.user_script_root = pathlib.Path(tempfile.gettempdir())
+    ops.register_passive_op(ENV, "Test Operation", inputs=[])
+    try:
+        yield
+    finally:
+        ops.load_catalogs("test_workspace")
+        ops.user_script_root = old_user_script_root
 
 
 def test_update_metadata():
-    ws = workspace.Workspace(env="test")
+    ws = workspace.Workspace(env=ENV)
     ws.add_node(
         id="1",
         type="basic",
@@ -94,6 +100,6 @@ def test_update_metadata():
 
 
 def test_update_metadata_with_empty_workspace():
-    ws = workspace.Workspace(env="test")
+    ws = workspace.Workspace(env=ENV)
     ws.update_metadata()
     assert len(ws.nodes) == 0


### PR DESCRIPTION
The workspace is loaded before we load user-scripts, making the metadata of custom boxes non-existent, so we perceive them as `Unknown operation.` If we load the scripts before we update the metadata, that fixes the boxes being unknown.

(Fixes #66)
