### PR TITLE
Fix disappearing edges when ungrouping

### DIFF
--- a/lynxkite-app/src/lynxkite_app/crdt.py
+++ b/lynxkite-app/src/lynxkite_app/crdt.py
@@ -300,7 +300,14 @@ def update_workspace(ws: pycrdt.Map, ws_pyd: workspace.Workspace):
             ws,
             ws_pyd.model_dump(),
             # We treat some fields as black boxes. They are not edited on the frontend.
-            non_collaborative_fields={"display", "input_metadata", "meta"},
+            non_collaborative_fields={
+                "display",
+                "input_metadata",
+                "meta",
+                "position",  # Edited, but we don't want to track x and y separately.
+                "output_metadata",
+                "telemetry",
+            },
         )
 
 

--- a/lynxkite-app/web/src/workspace/Workspace.tsx
+++ b/lynxkite-app/web/src/workspace/Workspace.tsx
@@ -506,7 +506,9 @@ function LynxKiteFlow() {
       for (const node of wnodes) {
         const g = groups[node.get("parentId") as string];
         if (!g) continue;
-        const pos = node.get("position") as XYPosition;
+        const posValue = node.get("position");
+        // Yjs position values can be either a plain object or a Y.Map with a toJSON method.
+        const pos = (posValue.toJSON ? posValue.toJSON() : posValue) as XYPosition;
         node.set("position", {
           x: pos.x + g.position.x,
           y: pos.y + g.position.y,


### PR DESCRIPTION
Fixes #284. Sometimes position is a normal JavaScript object and `pos.x`/`pos.y` works. Sometimes it's a Y.Map where you need `pos.get("x")`/`pos.get("y")`. (Or `pos.toJSON()` to get a normal JavaScript object.) In the latter case the existing code didn't find the x/y coordinates and ended up with NaN for the edges' coordinates, effectively making the edges disappear.

As for why `position` is sometimes a JavaScript object, sometimes a Y.Map, I think it depends on the history of the object. If it was loaded from a lynxkite.json file, it's a Y.Map, if it was created on the frontend, it's a plain object. I've tried to fix this with the second commit. But I think we can still keep the first commit. It's easier to test.