### PR TITLE
Add hierarchical settings in folders

### DIFF
--- a/lynxkite-assistant/tests/test_end-to-end.py
+++ b/lynxkite-assistant/tests/test_end-to-end.py
@@ -17,7 +17,7 @@ def setup_workspace():
     yield
 
     ops.user_script_root = ops_usr
-    workspace_backend.crdt = wb_crdt  # type: ignore
+    workspace_backend.crdt = wb_crdt
 
 
 @pytest.fixture

--- a/lynxkite-core/pyproject.toml
+++ b/lynxkite-core/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
     "pydantic>=2.11.7",
     "pydantic-core>=2.46.4",
+    "pyyaml>=6.0.2",
 ]
 license = "AGPL-3.0-or-later"
 

--- a/lynxkite-core/pyproject.toml
+++ b/lynxkite-core/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
     "pydantic>=2.11.7",
     "pydantic-core>=2.46.4",
-    "pyyaml>=6.0.2",
+    "pyyaml>=6.0.3",
 ]
 license = "AGPL-3.0-or-later"
 

--- a/lynxkite-core/src/lynxkite_core/folder_settings.py
+++ b/lynxkite-core/src/lynxkite_core/folder_settings.py
@@ -1,35 +1,13 @@
-"""Per-folder settings.yaml for configs. It holds LIM box configs, and later can be used for ACL configs."""
+"""Per-folder settings.yaml loading and hierarchical merge helpers."""
 
 from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
 
-import pydantic
 import yaml
 
 SETTINGS_FILENAME = "settings.yaml"
-
-
-class LimBoxConfig(pydantic.BaseModel):
-    model_config = pydantic.ConfigDict(extra="ignore")
-    cpu: str | None = None
-    memory: str | None = None
-    image: str | None = None
-    port: int | None = None
-    namespace: str | None = None
-    env: list[dict[str, Any]] | None = None
-    forward_env: list[str] | None = None
-    storage_size: str | None = None
-    storage_host_path: str | None = None
-    timeout_seconds: int | None = None
-    startup_timeout: int | None = None
-    args: list[str] | None = None
-
-
-class FolderSettings(pydantic.BaseModel):
-    model_config = pydantic.ConfigDict(extra="ignore")
-    lim: dict[str, LimBoxConfig] = pydantic.Field(default_factory=dict)
 
 
 def _containing_dirs(data_root: Path, workspace_path: str) -> list[Path]:
@@ -45,8 +23,10 @@ def _containing_dirs(data_root: Path, workspace_path: str) -> list[Path]:
     return dirs
 
 
-def resolve_lim_for_box(data_root: Path, workspace_path: str, op_id: str) -> dict[str, Any] | None:
-    """Load settings.yaml from root → workspace folder; return merged LIM config for op_id."""
+def resolve_settings_section(
+    data_root: Path, workspace_path: str, section: str
+) -> dict[str, dict[str, Any]]:
+    """Load settings.yaml from root→workspace folder; merge requested top-level section."""
     merged: dict[str, dict[str, Any]] = {}
     for directory in _containing_dirs(data_root, workspace_path):
         settings_path = directory / SETTINGS_FILENAME
@@ -54,8 +34,11 @@ def resolve_lim_for_box(data_root: Path, workspace_path: str, op_id: str) -> dic
             continue
         with settings_path.open(encoding="utf-8") as handle:
             raw = yaml.safe_load(handle) or {}
-        settings = FolderSettings.model_validate(raw)
-        for box_id, box in settings.lim.items():
-            merged.setdefault(box_id, {}).update(box.model_dump(exclude_none=True))
-    result = merged.get(op_id)
-    return result or None
+        values = raw.get(section)
+        if not isinstance(values, dict):
+            continue
+        for key, value in values.items():
+            if not isinstance(key, str) or not isinstance(value, dict):
+                continue
+            merged.setdefault(key, {}).update(value)
+    return merged

--- a/lynxkite-core/src/lynxkite_core/folder_settings.py
+++ b/lynxkite-core/src/lynxkite_core/folder_settings.py
@@ -1,0 +1,61 @@
+"""Per-folder settings.yaml for configs. It holds LIM box configs, and later can be used for ACL configs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pydantic
+import yaml
+
+SETTINGS_FILENAME = "settings.yaml"
+
+
+class LimBoxConfig(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="ignore")
+    cpu: str | None = None
+    memory: str | None = None
+    image: str | None = None
+    port: int | None = None
+    namespace: str | None = None
+    env: list[dict[str, Any]] | None = None
+    forward_env: list[str] | None = None
+    storage_size: str | None = None
+    storage_host_path: str | None = None
+    timeout_seconds: int | None = None
+    startup_timeout: int | None = None
+    args: list[str] | None = None
+
+
+class FolderSettings(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="ignore")
+    lim: dict[str, LimBoxConfig] = pydantic.Field(default_factory=dict)
+
+
+def _containing_dirs(data_root: Path, workspace_path: str) -> list[Path]:
+    path = workspace_path.replace("\\", "/")
+    if path.endswith(".lynxkite.json"):
+        path = path.rsplit("/", 1)[0] if "/" in path else ""
+    else:
+        path = path.strip("/")
+    dirs = [data_root]
+    if path:
+        parts = path.split("/")
+        dirs.extend(data_root / "/".join(parts[: i + 1]) for i in range(len(parts)))
+    return dirs
+
+
+def resolve_lim_for_box(data_root: Path, workspace_path: str, op_id: str) -> dict[str, Any] | None:
+    """Load settings.yaml from root → workspace folder; return merged LIM config for op_id."""
+    merged: dict[str, dict[str, Any]] = {}
+    for directory in _containing_dirs(data_root, workspace_path):
+        settings_path = directory / SETTINGS_FILENAME
+        if not settings_path.is_file():
+            continue
+        with settings_path.open(encoding="utf-8") as handle:
+            raw = yaml.safe_load(handle) or {}
+        settings = FolderSettings.model_validate(raw)
+        for box_id, box in settings.lim.items():
+            merged.setdefault(box_id, {}).update(box.model_dump(exclude_none=True))
+    result = merged.get(op_id)
+    return result or None

--- a/lynxkite-core/tests/test_folder_settings.py
+++ b/lynxkite-core/tests/test_folder_settings.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 import yaml
 
-from lynxkite_core.folder_settings import resolve_lim_for_box
+from lynxkite_core.folder_settings import resolve_settings_section
 
 
-def test_resolve_lim_for_box_merges_parent_and_child(tmp_path: Path):
+def test_resolve_settings_section_merges_parent_and_child(tmp_path: Path):
     (tmp_path / "settings.yaml").write_text(
         yaml.dump({"lim": {"Box A": {"memory": "8Gi", "cpu": "2"}}}),
         encoding="utf-8",
@@ -19,25 +19,27 @@ def test_resolve_lim_for_box_merges_parent_and_child(tmp_path: Path):
         encoding="utf-8",
     )
 
-    assert resolve_lim_for_box(tmp_path, "heavy/ws.lynxkite.json", "Box A") == {
+    merged = resolve_settings_section(tmp_path, "heavy/ws.lynxkite.json", "lim")
+    assert merged["Box A"] == {
         "memory": "16Gi",
         "cpu": "2",
     }
 
 
-def test_resolve_lim_for_box_missing_returns_none(tmp_path: Path):
-    assert resolve_lim_for_box(tmp_path, "ws.lynxkite.json", "Box A") is None
+def test_resolve_settings_section_missing_returns_empty(tmp_path: Path):
+    assert resolve_settings_section(tmp_path, "ws.lynxkite.json", "lim") == {}
 
 
-def test_resolve_lim_for_box_returns_dict(tmp_path: Path):
+def test_resolve_settings_section_returns_dict(tmp_path: Path):
     (tmp_path / "settings.yaml").write_text(
         yaml.dump({"lim": {"Box A": {"memory": "4Gi"}}}),
         encoding="utf-8",
     )
-    assert resolve_lim_for_box(tmp_path, "ws.lynxkite.json", "Box A") == {"memory": "4Gi"}
+    merged = resolve_settings_section(tmp_path, "ws.lynxkite.json", "lim")
+    assert merged["Box A"] == {"memory": "4Gi"}
 
 
-def test_resolve_lim_for_box_merges_multiple_levels(tmp_path: Path):
+def test_resolve_settings_section_merges_multiple_levels(tmp_path: Path):
     (tmp_path / "settings.yaml").write_text(
         yaml.dump({"lim": {"Box A": {"cpu": "1", "memory": "4Gi"}}}),
         encoding="utf-8",
@@ -55,13 +57,14 @@ def test_resolve_lim_for_box_merges_multiple_levels(tmp_path: Path):
         encoding="utf-8",
     )
 
-    assert resolve_lim_for_box(tmp_path, "team/project/ws.lynxkite.json", "Box A") == {
+    merged = resolve_settings_section(tmp_path, "team/project/ws.lynxkite.json", "lim")
+    assert merged["Box A"] == {
         "cpu": "3",
         "memory": "8Gi",
     }
 
 
-def test_resolve_lim_for_box_only_returns_target_box(tmp_path: Path):
+def test_resolve_settings_section_keeps_boxes_isolated(tmp_path: Path):
     (tmp_path / "settings.yaml").write_text(
         yaml.dump(
             {
@@ -80,14 +83,15 @@ def test_resolve_lim_for_box_only_returns_target_box(tmp_path: Path):
         encoding="utf-8",
     )
 
-    assert resolve_lim_for_box(tmp_path, "team/ws.lynxkite.json", "Box A") == {"cpu": "1"}
-    assert resolve_lim_for_box(tmp_path, "team/ws.lynxkite.json", "Box B") == {
+    merged = resolve_settings_section(tmp_path, "team/ws.lynxkite.json", "lim")
+    assert merged["Box A"] == {"cpu": "1"}
+    assert merged["Box B"] == {
         "cpu": "2",
         "memory": "16Gi",
     }
 
 
-def test_resolve_lim_for_box_accepts_workspace_path_without_suffix(tmp_path: Path):
+def test_resolve_settings_section_accepts_workspace_path_without_suffix(tmp_path: Path):
     (tmp_path / "settings.yaml").write_text(
         yaml.dump({"lim": {"Box A": {"cpu": "1"}}}),
         encoding="utf-8",
@@ -99,4 +103,5 @@ def test_resolve_lim_for_box_accepts_workspace_path_without_suffix(tmp_path: Pat
         encoding="utf-8",
     )
 
-    assert resolve_lim_for_box(tmp_path, "team", "Box A") == {"cpu": "1", "memory": "8Gi"}
+    merged = resolve_settings_section(tmp_path, "team", "lim")
+    assert merged["Box A"] == {"cpu": "1", "memory": "8Gi"}

--- a/lynxkite-core/tests/test_folder_settings.py
+++ b/lynxkite-core/tests/test_folder_settings.py
@@ -1,0 +1,102 @@
+"""Tests for per-folder settings.yaml."""
+
+from pathlib import Path
+
+import yaml
+
+from lynxkite_core.folder_settings import resolve_lim_for_box
+
+
+def test_resolve_lim_for_box_merges_parent_and_child(tmp_path: Path):
+    (tmp_path / "settings.yaml").write_text(
+        yaml.dump({"lim": {"Box A": {"memory": "8Gi", "cpu": "2"}}}),
+        encoding="utf-8",
+    )
+    child = tmp_path / "heavy"
+    child.mkdir()
+    (child / "settings.yaml").write_text(
+        yaml.dump({"lim": {"Box A": {"memory": "16Gi"}}}),
+        encoding="utf-8",
+    )
+
+    assert resolve_lim_for_box(tmp_path, "heavy/ws.lynxkite.json", "Box A") == {
+        "memory": "16Gi",
+        "cpu": "2",
+    }
+
+
+def test_resolve_lim_for_box_missing_returns_none(tmp_path: Path):
+    assert resolve_lim_for_box(tmp_path, "ws.lynxkite.json", "Box A") is None
+
+
+def test_resolve_lim_for_box_returns_dict(tmp_path: Path):
+    (tmp_path / "settings.yaml").write_text(
+        yaml.dump({"lim": {"Box A": {"memory": "4Gi"}}}),
+        encoding="utf-8",
+    )
+    assert resolve_lim_for_box(tmp_path, "ws.lynxkite.json", "Box A") == {"memory": "4Gi"}
+
+
+def test_resolve_lim_for_box_merges_multiple_levels(tmp_path: Path):
+    (tmp_path / "settings.yaml").write_text(
+        yaml.dump({"lim": {"Box A": {"cpu": "1", "memory": "4Gi"}}}),
+        encoding="utf-8",
+    )
+    child = tmp_path / "team"
+    child.mkdir()
+    (child / "settings.yaml").write_text(
+        yaml.dump({"lim": {"Box A": {"memory": "8Gi"}}}),
+        encoding="utf-8",
+    )
+    grandchild = child / "project"
+    grandchild.mkdir()
+    (grandchild / "settings.yaml").write_text(
+        yaml.dump({"lim": {"Box A": {"cpu": "3"}}}),
+        encoding="utf-8",
+    )
+
+    assert resolve_lim_for_box(tmp_path, "team/project/ws.lynxkite.json", "Box A") == {
+        "cpu": "3",
+        "memory": "8Gi",
+    }
+
+
+def test_resolve_lim_for_box_only_returns_target_box(tmp_path: Path):
+    (tmp_path / "settings.yaml").write_text(
+        yaml.dump(
+            {
+                "lim": {
+                    "Box A": {"cpu": "1"},
+                    "Box B": {"cpu": "2"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    child = tmp_path / "team"
+    child.mkdir()
+    (child / "settings.yaml").write_text(
+        yaml.dump({"lim": {"Box B": {"memory": "16Gi"}}}),
+        encoding="utf-8",
+    )
+
+    assert resolve_lim_for_box(tmp_path, "team/ws.lynxkite.json", "Box A") == {"cpu": "1"}
+    assert resolve_lim_for_box(tmp_path, "team/ws.lynxkite.json", "Box B") == {
+        "cpu": "2",
+        "memory": "16Gi",
+    }
+
+
+def test_resolve_lim_for_box_accepts_workspace_path_without_suffix(tmp_path: Path):
+    (tmp_path / "settings.yaml").write_text(
+        yaml.dump({"lim": {"Box A": {"cpu": "1"}}}),
+        encoding="utf-8",
+    )
+    child = tmp_path / "team"
+    child.mkdir()
+    (child / "settings.yaml").write_text(
+        yaml.dump({"lim": {"Box A": {"memory": "8Gi"}}}),
+        encoding="utf-8",
+    )
+
+    assert resolve_lim_for_box(tmp_path, "team", "Box A") == {"cpu": "1", "memory": "8Gi"}

--- a/lynxkite-graph-analytics/src/lynxkite_graph_analytics/elementwise.py
+++ b/lynxkite-graph-analytics/src/lynxkite_graph_analytics/elementwise.py
@@ -11,16 +11,16 @@ from lynxkite_core.ops import OpContext
 
 try:
     from lynxkite_enterprise.execution import execution_parallelism  # ty: ignore[unresolved-import]
-    from lynxkite_enterprise.lim import (
+    from lynxkite_enterprise.lim import (  # ty: ignore[unresolved-import]
         LIM_ATTR,
         remote_row_processor,
-    )  # ty: ignore[unresolved-import]
+    )
 
     enterprise_backend = True
 except ImportError:
     enterprise_backend = False
-    execution_parallelism = None  # type: ignore[assignment,misc]
-    remote_row_processor = None  # type: ignore[assignment,misc]
+    execution_parallelism = None
+    remote_row_processor = None
     LIM_ATTR = "__lynxkite_lim__"
 
 from .bundle import Bundle
@@ -157,10 +157,10 @@ async def _elementwise_impl_async(
         return record.get_updates()
 
     lim_cleanup = None
-    if enterprise_backend and getattr(func, LIM_ATTR, False):
+    if enterprise_backend and getattr(func, LIM_ATTR, False) and remote_row_processor is not None:
         remote = await remote_row_processor(func, self, kwargs)
         if remote is not None:
-            process_row_updates = remote  # type: ignore[assignment]
+            process_row_updates = remote
             lim_cleanup = getattr(remote, "lim_cleanup", None)
 
     try:

--- a/lynxkite-graph-analytics/src/lynxkite_graph_analytics/elementwise.py
+++ b/lynxkite-graph-analytics/src/lynxkite_graph_analytics/elementwise.py
@@ -11,15 +11,17 @@ from lynxkite_core.ops import OpContext
 
 try:
     from lynxkite_enterprise.execution import execution_parallelism  # ty: ignore[unresolved-import]
-    from lynxkite_enterprise.lim import (  # ty: ignore[unresolved-import]
-        get_remote_row_processor,
-        register_lim_function_if_worker,
-    )
+    from lynxkite_enterprise.lim import (
+        LIM_ATTR,
+        remote_row_processor,
+    )  # ty: ignore[unresolved-import]
 
     enterprise_backend = True
 except ImportError:
     enterprise_backend = False
     execution_parallelism = None  # type: ignore[assignment,misc]
+    remote_row_processor = None  # type: ignore[assignment,misc]
+    LIM_ATTR = "__lynxkite_lim__"
 
 from .bundle import Bundle
 from .record import ColumnKey, Record, RowIndex
@@ -31,7 +33,6 @@ def elementwise(
     input_table: str,
     desc: str = "",
     concurrency: int = 1,
-    lim_config: typing.Any = None,
 ) -> typing.Callable:
     """Decorator for operations that process each row independently.
 
@@ -49,15 +50,12 @@ def elementwise(
         async def process(record: Record, *, protein_table_column: TableColumn):
             record.result = await api_call(record[protein_table_column])
 
-    If LynxKite 2000:MM Enterprise is installed, you can run elementwise operations on Kubernetes
-    as LIMs. With LIM, pass a small ``lim_config``; storage and k8s defaults are filled in
-    automatically:
+    With LynxKite Enterprise, mark LIM-capable row functions with ``@lim`` and configure
+    resources per folder in ``settings.yaml``:
+
         @op("ESM2", slow=True)
-        @elementwise(
-            input_table="protein_table_column",
-            desc="ESM2",
-            lim_config={"cpu": "4", "memory": "8Gi"},
-        )
+        @elementwise(input_table="protein_table_column", desc="ESM2")
+        @lim
         def query_esm2(record: Record, *, protein_table_column: TableColumn) -> None:
             record.embeddings = my_inference(record[protein_table_column])
     """
@@ -71,11 +69,9 @@ def elementwise(
                 f"@elementwise requires 'record: Record' as first parameter, got: {params[0].name if params else 'none'}"
             )
 
-        service_name = None
-        if lim_config and not enterprise_backend:
-            raise ValueError("@elementwise(lim_config=...) requires LynxKite Enterprise")
-        if enterprise_backend and lim_config:
-            service_name = register_lim_function_if_worker(func, lim_config)
+        is_lim = getattr(func, LIM_ATTR, False)
+        if is_lim and not enterprise_backend:
+            raise ValueError("@lim requires LynxKite Enterprise")
 
         public_signature = sig.replace(
             parameters=[
@@ -85,7 +81,7 @@ def elementwise(
             ]
         )
 
-        if inspect.iscoroutinefunction(func) or lim_config or concurrency > 1:
+        if inspect.iscoroutinefunction(func) or is_lim or concurrency > 1:
 
             async def async_wrapper(
                 self: OpContext,
@@ -101,8 +97,6 @@ def elementwise(
                     kwargs,
                     desc=desc,
                     concurrency=concurrency,
-                    lim_config=lim_config,
-                    service_name=service_name,
                 )
 
             setattr(async_wrapper, "__signature__", public_signature)
@@ -120,8 +114,6 @@ def elementwise(
                         kwargs,
                         desc=desc,
                         concurrency=concurrency,
-                        lim_config=None,
-                        service_name=None,
                     )
                 )
             return _elementwise_impl_sync(
@@ -148,8 +140,6 @@ async def _elementwise_impl_async(
     *,
     desc: str,
     concurrency: int,
-    lim_config: typing.Any | None,
-    service_name: str | None,
 ) -> Bundle:
     bundle, table_name, df = _prepare_elementwise(
         bundle=bundle,
@@ -167,16 +157,11 @@ async def _elementwise_impl_async(
         return record.get_updates()
 
     lim_cleanup = None
-    if service_name and lim_config:
-        remote_processor = await get_remote_row_processor(
-            self,
-            kwargs,
-            service_name=service_name,
-            lim_config=lim_config,
-        )
-        if remote_processor is not None:
-            process_row_updates = remote_processor  # type: ignore[assignment]
-            lim_cleanup = getattr(remote_processor, "lim_cleanup", None)
+    if enterprise_backend and getattr(func, LIM_ATTR, False):
+        remote = await remote_row_processor(func, self, kwargs)
+        if remote is not None:
+            process_row_updates = remote  # type: ignore[assignment]
+            lim_cleanup = getattr(remote, "lim_cleanup", None)
 
     try:
         await _process_rows_concurrently(


### PR DESCRIPTION
`settings.yaml` files store configuration for a folder. Settings are inherited by child folders, with child values overriding those from parent folders. These files will be used to store LIM configurations and are also a suitable place for ACLs for #215 and #216.